### PR TITLE
Add garbd package and arbitrator job

### DIFF
--- a/jobs/arbitrator/monit
+++ b/jobs/arbitrator/monit
@@ -1,0 +1,5 @@
+check process garbd
+  with pidfile /var/vcap/sys/run/arbitrator/garbd.pid
+  start program "/var/vcap/jobs/arbitrator/bin/garbd_ctl start" with timeout 60 seconds
+  stop program "/var/vcap/jobs/arbitrator/bin/garbd_ctl stop" with timeout 10 seconds
+  group vcap

--- a/jobs/arbitrator/spec
+++ b/jobs/arbitrator/spec
@@ -1,0 +1,34 @@
+---
+name: arbitrator
+
+templates:
+  garbd_ctl.erb: bin/garbd_ctl
+  garbd_config.erb: config/garbd_config
+  galera-ca.pem.erb: certificates/galera-ca.pem
+  galera-cert.pem.erb: certificates/galera-cert.pem
+  galera-key.pem.erb: certificates/galera-key.pem
+
+packages:
+- garbd
+
+consumes:
+- name: mysql
+  type: mysql
+  optional: true
+- name: arbitrator
+  type: arbitrator
+  optional: true
+
+provides:
+- name: arbitrator
+  type: arbitrator
+
+# Properties names are intentionally same as in pxc-mysql
+# They need to be configured to same vaules, in order for arbitrator to connect with rest of cluster
+properties:
+  cf_mysql.mysql.galera_port:
+    description: 'Galera SSL cluster port'
+    default: 4567
+
+  tls.galera:
+    description: 'Required: TLS certificate for galera cluster encryption'

--- a/jobs/arbitrator/templates/galera-ca.pem.erb
+++ b/jobs/arbitrator/templates/galera-ca.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.galera.ca') %>

--- a/jobs/arbitrator/templates/galera-cert.pem.erb
+++ b/jobs/arbitrator/templates/galera-cert.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.galera.certificate') %>

--- a/jobs/arbitrator/templates/galera-key.pem.erb
+++ b/jobs/arbitrator/templates/galera-key.pem.erb
@@ -1,0 +1,1 @@
+<%= p('tls.galera.private_key') %>

--- a/jobs/arbitrator/templates/garbd_config.erb
+++ b/jobs/arbitrator/templates/garbd_config.erb
@@ -1,0 +1,10 @@
+options = "socket.ssl_cipher=AES128-SHA;socket.ssl_ca=/var/vcap/jobs/arbitrator/certificates/galera-ca.pem;socket.ssl_cert=/var/vcap/jobs/arbitrator/certificates/galera-cert.pem;socket.ssl_key=/var/vcap/jobs/arbitrator/certificates/galera-key.pem"
+group = galera-cluster
+
+<%cluster_ips = []
+  cluster_ips = link('mysql').instances.map { |instance| instance.address }
+  cluster_ips += link('arbitrator').instances.map { |instance| instance.address }
+
+  galera_port = p('cf_mysql.mysql.galera_port')
+  node_addresses = cluster_ips.map { |ip| "#{ip}:#{galera_port}" } %>
+address = gcomm://<%= node_addresses.join(',') %>

--- a/jobs/arbitrator/templates/garbd_ctl.erb
+++ b/jobs/arbitrator/templates/garbd_ctl.erb
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+job_dir=/var/vcap/jobs/arbitrator
+run_dir=/var/vcap/sys/run/arbitrator
+log_dir=/var/vcap/sys/log/arbitrator
+package_dir=/var/vcap/packages/garbd
+pidfile=$run_dir/garbd.pid
+
+case $1 in
+
+start)
+  echo "Starting Galera Arbitrator..."
+
+  mkdir -p $run_dir
+  mkdir -p $log_dir
+
+  # Check if it's running
+  if ps axf | grep -v grep | grep "$package_dir/bin/garbd" ; then
+    echo "garbd seems already running. Stop it first before starting again."
+    exit 1
+  fi
+
+  echo $$ > $pidfile
+  chown vcap:vcap $pidfile
+
+  exec chpst -u vcap:vcap $package_dir/bin/garbd \
+    --cfg $job_dir/config/garbd_config \
+    >>$log_dir/garbd.stdout.log \
+    2>>$log_dir/garbd.stderr.log
+
+  echo "Starting garbd... done"
+;;
+
+stop)
+  echo "Stopping garbd..."
+  kill $(cat $pidfile) && rm $pidfile
+  echo "Stopping garbd... done"
+;;
+
+*)
+  echo "Usage: garbd_ctl {start|stop}"
+;;
+
+esac

--- a/packages/garbd/packaging
+++ b/packages/garbd/packaging
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+source /var/vcap/packages/python-2.7/bosh/compile.env
+
+set -u
+
+NPROC=$(nproc)
+GALERA_REVISION="03540a383884e5784cc707dd22087a031b5bcbb8"
+
+tar -xf check/check-*.tar.gz
+pushd check-*/
+    ./configure --prefix=/usr
+    make -j "${NPROC}"
+    make -j "${NPROC}" install
+popd
+
+tar -xf boost/boost_1_59_0.tar.gz
+pushd boost_1_59_0
+    ./bootstrap.sh --with-libraries=program_options,system --prefix=/usr
+    ./b2 -j "${NPROC}" install
+popd
+
+tar -xf scons/scons-*.tar.gz
+pushd scons-*/
+    python setup.py install --prefix=/usr
+popd
+
+tar -xf pxc/Percona-XtraDB-Cluster-*.tar.gz
+pushd Percona-XtraDB-Cluster-*/percona-xtradb-cluster-galera
+    export HOME=/var/vcap/data/compile/garbd
+
+    scons -j $NPROC --config=force revno="$GALERA_REVISION" garb/garbd
+
+    # Build version with statically linked boost, as that is not available on stemcells
+    g++ -o garb/garbd.static -m64 -Wl,-melf_x86_64 \
+      garb/garb_logger.o garb/garb_gcs.o garb/garb_recv_loop.o garb/garb_main.o garb/garb_config.os \
+      gcs/src/libgcs4garb.a gcomm/src/libgcomm.a galerautils/src/libgalerautils++.a galerautils/src/libgalerautils.a \
+      -lpthread -lrt -lssl -lcrypto ../../boost_1_59_0/bin.v2/libs/program_options/build/gcc-5.4.0/release/link-static/threading-multi/libboost_program_options.a
+
+    mkdir -p "${BOSH_INSTALL_TARGET}/bin"
+    cp garb/garbd.static "${BOSH_INSTALL_TARGET}/bin/garbd"
+popd

--- a/packages/garbd/spec
+++ b/packages/garbd/spec
@@ -1,0 +1,11 @@
+---
+name: garbd
+
+dependencies:
+- python-2.7
+
+files:
+- boost/boost_1_59_0.tar.gz
+- check/check-*.tar.gz
+- pxc/Percona-XtraDB-Cluster-*.tar.gz
+- scons/scons-*.tar.gz


### PR DESCRIPTION
Open for suggestions. Currently requires SSL. Does static linking on boost, so that it can run on stemcell without requiring local dynamic libs.

Initial issue here: https://github.com/cloudfoundry-incubator/pxc-release/issues/8
