### PR TITLE
5.7 crash recovery with 8.0 collation-server options

### DIFF
--- a/jobs/pxc-mysql/templates/pre-start.sh.erb
+++ b/jobs/pxc-mysql/templates/pre-start.sh.erb
@@ -140,13 +140,14 @@ function check_bpm_pid {
     /var/vcap/jobs/bpm/bin/bpm pid pxc-mysql -p galera-init >/dev/null 2>&1
 }
 
+# TODO will this get run every time we start a 5.7 DB now?
 function is_pxc57_datadir {
   [[ -f /var/vcap/store/pxc-mysql/mysql/user.frm ]]
 }
 
 function apply_pxc57_crash_recovery {
   local recovery_log=/var/vcap/sys/log/pxc-mysql/pxc-57-recovery.log
-  if /var/vcap/packages/percona-xtradb-cluster-5.7/bin/mysqld --wsrep-recover --disable-log-error &> "${recovery_log}"; then
+  if /var/vcap/packages/percona-xtradb-cluster-5.7/bin/mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --wsrep-recover --disable-log-error &> "${recovery_log}"; then
     log "pre-start: recovered percona-xtradb-cluster 5.7 data directory prior to upgrade"
   else
     log "pre-start: [FAIL] unable to recover percona-xtradb-cluster 5.7 data directory prior to upgrade"

--- a/operations/test/collation-server.yml
+++ b/operations/test/collation-server.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/engine_config?/collation_server
+  value: utf8mb4_0900_ai_ci

--- a/src/e2e-tests/upgrade_test.go
+++ b/src/e2e-tests/upgrade_test.go
@@ -59,10 +59,11 @@ var _ = Describe("Upgrade", Label("upgrade"), func() {
 		Expect(credhub.Regenerate("/" + deploymentName + "/cf_mysql_mysql_cluster_health_password")).
 			To(Succeed())
 
-		By("upgrading pxc-release based on PXC 8.0")
+		By("upgrading pxc-release based on PXC 8.0 and using a collation-server not compatible with 5.7")
 		Expect(bosh.DeployPXC(deploymentName,
 			bosh.Operation("use-clustered.yml"),
 			bosh.Operation("dev-release.yml"),
+			bosh.Operation("test/collation-server.yml"),
 		)).To(Succeed())
 
 		Expect(bosh.RunErrand(deploymentName, "smoke-tests", "mysql/first")).To(Succeed())


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
pre-start script for Percona 5.7 crash recovery 

# Motivation
A Percona 8.0 my.cnf is incompatible with Percona 5.7. This allows crash recovery to succeed if that configuration value is set.

# Related Issue
If this PR was first opened as an issue, please provide the link to that issue here.

