### PR TITLE
Do not run crash recovery at normal startup

### DIFF
--- a/jobs/pxc-mysql/templates/pre-start.sh.erb
+++ b/jobs/pxc-mysql/templates/pre-start.sh.erb
@@ -140,7 +140,7 @@ function check_bpm_pid {
     /var/vcap/jobs/bpm/bin/bpm pid pxc-mysql -p galera-init >/dev/null 2>&1
 }
 
-# TODO will this get run every time we start a 5.7 DB now?
+<%- if p('mysql_version') == "8.0" -%>
 function is_pxc57_datadir {
   [[ -f /var/vcap/store/pxc-mysql/mysql/user.frm ]]
 }
@@ -160,6 +160,7 @@ if is_pxc57_datadir; then
 else
   log "pre-start: skipping special crash recovery. percona-xtradb-cluster 5.7 data directory not detected."
 fi
+<%- end -%>
 
 if ! /var/vcap/jobs/bpm/bin/bpm start pxc-mysql -p galera-init; then
     log "pre-start: galera-init failed to initialize"

--- a/spec/pxc-mysql/pre_start_spec.rb
+++ b/spec/pxc-mysql/pre_start_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec'
+require 'json'
+require 'yaml'
+require 'bosh/template/test'
+
+describe 'galera-agent-config template' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('pxc-mysql') }
+  let(:template) { job.template('bin/pre-start') }
+  let(:spec) { {} }
+  let(:rendered_template) { template.render(spec) }
+
+  context 'when mysql_version is explicitly set to 8.0' do
+    before { spec["mysql_version"] = "8.0" }
+    it 'includes a apply_pxc57_crash_recovery function' do
+      expect(rendered_template).to include("apply_pxc57_crash_recovery")
+    end
+  end
+
+  context 'when mysql_version is set to 5.7' do
+    before { spec["mysql_version"] = "5.7" }
+    it 'does not includes a apply_pxc57_crash_recovery function' do
+      expect(rendered_template).to_not include("apply_pxc57_crash_recovery")
+    end
+  end
+end

--- a/src/e2e-tests/singlenode_test.go
+++ b/src/e2e-tests/singlenode_test.go
@@ -65,4 +65,9 @@ var _ = Describe(fmt.Sprintf("Single Node for PXC version %s", expectedMysqlVers
 			To(Succeed())
 		Expect(queryResultString).ToNot(BeEmpty())
 	})
+	It("does not go through crash recovery", func() {
+		output, err := bosh.Logs(deploymentName, "mysql/0", "pxc-mysql/pxc-57-recovery.log")
+		Expect(output.String()).To(ContainSubstring(`cannot open '/var/vcap/sys/log/pxc-mysql/pxc-57-recovery.log' for reading: No such file or directory`))
+		Expect(err).To(HaveOccurred())
+	})
 })


### PR DESCRIPTION
Crash recovery should only be run if a 5.7 instance has crashed and an attempt is being made to upgrade to 8.0

[#183977172]

Co-authored-by: Colin Shield <cshield@vmware.com>
Co-authored-by: Kevin Markwardt <kmarkwardt@vmware.com>

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
Don't run crash behavior unless an upgrade from 5.7 to 8.0 is being performed.  

# Motivation
Crash recovery was being run on every 5.7 startup. This isn't required and could be confusing to users.
