### PR TITLE
packages: allow parallel compilation of server and xtrabackup packages

### DIFF
--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -30,13 +30,11 @@ install_build_dependencies() {
 }
 
 install_runtime_dependencies() {
-  mkdir -p "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-2.4"
-  mkdir -p "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-8.0"
+  mkdir -p "${BOSH_INSTALL_TARGET}/bin/pxc_extra"
 
   local version
-  for version in 2.4 8.0;do
-  tar -C /var/vcap/packages/percona-xtrabackup-"${version}" -c . \
-    | tar -C "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-${version}/" -x
+  for version in 2.4 8.0; do
+    ln -sf "/var/vcap/packages/percona-xtrabackup-${version}" "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-${version}"
   done
 
   tar -xf socat-*.tar.gz
@@ -60,7 +58,7 @@ build() {
     wsrep_version="$(grep WSREP_INTERFACE_VERSION wsrep-lib/wsrep-API/v26/wsrep_api.h | cut -d '"' -f2).$(grep 'SET(WSREP_PATCH_VERSION' "cmake/wsrep-lib.cmake" | cut -d '"' -f2)"
     compilation_comment="Percona XtraDB Cluster (GPL) ${mysql_version}, WSREP version ${wsrep_version}"
 
-    echo "${mysql_version}" > "${BOSH_INSTALL_TARGET}/VERSION"
+    echo "${mysql_version}" >"${BOSH_INSTALL_TARGET}/VERSION"
 
     mkdir bld && cd bld
     cmake .. \
@@ -92,7 +90,7 @@ build() {
       -DWITH_WSREP=ON \
       -DWITH_ZLIB=bundled
 
-      make -j "$(nproc)" install/strip
+    make -j "$(nproc)" install/strip
   )
 
   (

--- a/packages/percona-xtradb-cluster-8.0/spec
+++ b/packages/percona-xtradb-cluster-8.0/spec
@@ -1,9 +1,7 @@
 ---
 name: percona-xtradb-cluster-8.0
 
-dependencies:
-- percona-xtrabackup-2.4
-- percona-xtrabackup-8.0
+dependencies: []
 
 files:
 - Percona-XtraDB-Cluster-8.0*.tar.gz


### PR DESCRIPTION
Previously percona-xtradb-cluster-8.0 depended on the percona-xtrabackup-* packages explicitly forcing serial compilation of xtrabackup and percona-xtradb-cluster.

With this change, percona-xtradb-cluster-8.0 instead relies on a symlink to percona-xtrabackup-{2.4,8.0} and can compile in parallel to the xtrabackup packages.

The "pxc-mysql" job already depended directly on percona-xtrabackup-8.0 and 2.4 so this is only a small optimization to speed up compilation and reduce the compiled bosh release by ~45MiB.  In practice we expect this to halve compilation time when > 3 bosh compilation workers are available.

# Feature or Bug Description

This change helps speed up pxc-release compilation in common deployment scenarios.

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

Compiling pxc-release from a new stemcell currently takes between 70 and 90 minutes on typically environments.   In some cases much more.   This change reduces that roughly by half by allowing Percona XtraDB Cluster to compilation in parallel to the Percona XtraBackup packages .