### PR TITLE
[Feature] proxy reports backend as "INSTANCE/UUID" rather than "backend-INDEX"

### DIFF
--- a/jobs/proxy/templates/proxy.yml.erb
+++ b/jobs/proxy/templates/proxy.yml.erb
@@ -36,7 +36,6 @@
     },
     HealthPort: p('health_port'),
     StaticDir: '/var/vcap/packages/proxy/static',
-    PidFile: '/var/vcap/sys/run/proxy/proxy.pid'
   }
 
   if link('galera-agent').p('endpoint_tls.enabled')
@@ -47,14 +46,12 @@
     }
   end
 
-  if_p('api_tls') do |endpoint_tls|
-  	if p('api_tls.enabled')
-		config[:API][:TLS] = {
-			Enabled: true,
-			Certificate: p('api_tls.certificate'),
-			PrivateKey: p('api_tls.private_key'),
-		}
-	end
+  if p('api_tls.enabled', false)
+    config[:API][:TLS] = {
+      Enabled: true,
+      Certificate: p('api_tls.certificate'),
+      PrivateKey: p('api_tls.private_key'),
+    }
   end
 
   if_p('inactive_mysql_port') do |inactive_mysql_port|

--- a/jobs/proxy/templates/proxy.yml.erb
+++ b/jobs/proxy/templates/proxy.yml.erb
@@ -1,8 +1,4 @@
 <%=
-  cluster_ips = link('mysql').instances.map { |instance| instance.address }
-  galera_agent_port = link('galera-agent').p('port')
-  mysql_port = link('mysql').p('port')
-
   proxy_uris = []
   if_p('api_uri') do |api_uri|
     proxy_uris = link('proxy').instances.map do |instance|
@@ -10,13 +6,13 @@
     end
   end
 
-  backends = cluster_ips.map.with_index do |ip, n|
+  backends = link('mysql').instances.map do |instance|
     {
-      Host: ip,
-      Port: mysql_port,
-      StatusPort: galera_agent_port,
+      Host: instance.address,
+      Port: link('mysql').p('port'),
+      StatusPort: link('galera-agent').p('port'),
       StatusEndpoint: 'api/v1/status',
-      Name: "backend-#{n}"
+      Name: "#{instance.name}/#{instance.id}",
     }
   end
 

--- a/spec/proxy/proxy_config_spec.rb
+++ b/spec/proxy/proxy_config_spec.rb
@@ -78,7 +78,6 @@ describe 'proxy.yml.erb configuration template' do
       },
       "HealthPort" => 1936,
       "StaticDir" => '/var/vcap/packages/proxy/static',
-      "PidFile" => "/var/vcap/sys/run/proxy/proxy.pid",
       "GaleraAgentTLS" => {
         "Enabled" => true,
         "CA" => "PEM Cert",

--- a/spec/proxy/proxy_config_spec.rb
+++ b/spec/proxy/proxy_config_spec.rb
@@ -1,0 +1,120 @@
+require 'rspec'
+require 'json'
+require 'yaml'
+require 'bosh/template/test'
+
+describe 'proxy.yml.erb configuration template' do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
+  let(:job) { release.job('proxy') }
+  let(:links) { [
+    Bosh::Template::Test::Link.new(
+      name: 'proxy',
+      instances: [
+        Bosh::Template::Test::LinkInstance.new(index: 0, address: 'proxy0-address'),
+        Bosh::Template::Test::LinkInstance.new(index: 1, address: 'proxy1-address'),
+      ],
+    ),
+
+    Bosh::Template::Test::Link.new(
+      name: 'mysql',
+      instances: [
+        Bosh::Template::Test::LinkInstance.new(id: "mysql0-uuid", address: 'mysql0-address'),
+        Bosh::Template::Test::LinkInstance.new(id: "mysql1-uuid", address: 'mysql1-address'),
+        Bosh::Template::Test::LinkInstance.new(id: "mysql2-uuid", address: 'mysql2-address'),
+      ],
+      properties: {
+        "port" => 6033,
+      }
+    ),
+    Bosh::Template::Test::Link.new(
+      name: 'galera-agent',
+      properties: {
+        "port" => "9201",
+        "endpoint_tls" => {
+          "enabled" => true,
+          "ca" => "PEM Cert",
+          "server_name" => "server name"
+        }
+      }
+    )
+  ] }
+  let(:template) { job.template('config/proxy.yml') }
+  let(:spec) {
+    {
+      "api_password" => "random-switchboard-password",
+      "healthcheck_timeout_millis" => 12345,
+      "api_uri" => "proxy.some-platform.domain",
+      "api_tls" => { "enabled" => true, "certificate" => "proxy-api-cert", "private_key" => "proxy-api-private-key" }
+    }
+  }
+  let(:parsed_config) {
+    YAML.load(template.render(spec, consumes: links))
+  }
+
+  it 'renders a valid proxy.yml' do
+    expected_config = {
+      "API" => {
+        "AggregatorPort" => 8082,
+        "ForceHttps" => true,
+        "Password" => "random-switchboard-password",
+        "Port" => 8080,
+        "ProxyURIs" => %w[0-proxy.some-platform.domain 1-proxy.some-platform.domain],
+        "Username" => "proxy",
+        "TLS" => {
+          "Enabled" => true,
+          "Certificate" => "proxy-api-cert",
+          "PrivateKey" => "proxy-api-private-key",
+        },
+      },
+
+      "Proxy" => {
+        "Port" => 3306,
+        "HealthcheckTimeoutMillis" => 12345,
+        "Backends" => [
+          { "Host" => "mysql0-address", "Name" => "backend-0", "Port" => 6033, "StatusEndpoint" => "api/v1/status", "StatusPort" => "9201" },
+          { "Host" => "mysql1-address", "Name" => "backend-1", "Port" => 6033, "StatusEndpoint" => "api/v1/status", "StatusPort" => "9201" },
+          { "Host" => "mysql2-address", "Name" => "backend-2", "Port" => 6033, "StatusEndpoint" => "api/v1/status", "StatusPort" => "9201" },
+        ],
+      },
+      "HealthPort" => 1936,
+      "StaticDir" => '/var/vcap/packages/proxy/static',
+      "PidFile" => "/var/vcap/sys/run/proxy/proxy.pid",
+      "GaleraAgentTLS" => {
+        "Enabled" => true,
+        "CA" => "PEM Cert",
+        "ServerName" => "server name",
+      }
+    }
+    expect(parsed_config).to eq(expected_config)
+  end
+
+  context 'when galera-agent disables tls' do
+    before(:each) do
+      links.select { |l| l.name == "galera-agent" }[0].properties["endpoint_tls"] = {
+        "enabled" => false
+      }
+    end
+
+    it 'does not configure GaleraAgentTLS' do
+      expect(parsed_config).to_not include("GaleraAgentTLS")
+    end
+  end
+
+  context 'the proxy api tls is disabled' do
+    before(:each) do
+      spec["api_tls"]["enabled"] = false
+    end
+
+    it 'does not configure GaleraAgentTLS' do
+      expect(parsed_config["API"]).to_not have_key("TLS")
+    end
+  end
+
+  context 'when inactive_mysql_port is configured' do
+    before(:each) { spec["inactive_mysql_port"] = 3307 }
+
+    it 'configures the InactiveMySQLPort property' do
+      expect(parsed_config["Proxy"]).to include("InactiveMysqlPort" => 3307)
+    end
+  end
+end

--- a/src/e2e-tests/bootstrap_test.go
+++ b/src/e2e-tests/bootstrap_test.go
@@ -1,7 +1,6 @@
 package e2e_tests
 
 import (
-	"crypto/tls"
 	"database/sql"
 	"encoding/json"
 	"io"
@@ -91,15 +90,6 @@ var _ = Describe("Bootstrapping an offline cluster", Ordered, Label("bootstrap")
 			By("mysql shutting down on all nodes")
 			mysqlIps, err := bosh.InstanceIPs(deploymentName, bosh.MatchByInstanceGroup("mysql"))
 			Expect(err).NotTo(HaveOccurred())
-
-			httpClient := &http.Client{
-				Transport: &http.Transport{
-					DialContext: proxyDialer,
-					TLSClientConfig: &tls.Config{
-						InsecureSkipVerify: true,
-					},
-				},
-			}
 
 			for _, ip := range mysqlIps {
 				stopMySQL(httpClient, ip)

--- a/src/e2e-tests/suite_test.go
+++ b/src/e2e-tests/suite_test.go
@@ -2,7 +2,9 @@ package e2e_tests
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -20,7 +22,7 @@ func TestE2E(t *testing.T) {
 }
 
 var (
-	proxyDialer          proxy.DialContextFunc
+	httpClient           *http.Client
 	expectedMysqlVersion string
 )
 
@@ -48,11 +50,20 @@ var _ = BeforeSuite(func() {
 
 	if proxySpec := os.Getenv("BOSH_ALL_PROXY"); proxySpec != "" {
 		var err error
-		proxyDialer, err = proxy.NewDialerViaSSH(context.Background(), proxySpec)
+		proxyDialer, err := proxy.NewDialerViaSSH(context.Background(), proxySpec)
 		Expect(err).NotTo(HaveOccurred())
 
 		mysql.RegisterDialContext("tcp", func(ctx context.Context, addr string) (net.Conn, error) {
 			return proxyDialer(ctx, "tcp", addr)
 		})
+
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				DialContext: proxyDialer,
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
 	}
 })

--- a/src/e2e-tests/verification_test.go
+++ b/src/e2e-tests/verification_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"crypto/tls"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/gstruct"
 
 	"e2e-tests/utilities/bosh"
 	"e2e-tests/utilities/credhub"
@@ -580,6 +583,48 @@ var _ = Describe("Feature Verification", Ordered, Label("verification"), func() 
 				Error().NotTo(HaveOccurred())
 			Expect(db.QueryRow(`SELECT data FROM multi_db2.t1 WHERE id = 1`).Scan(&storedValue)).To(Succeed())
 			Expect(storedValue).To(Equal(userValue))
+		})
+	})
+
+	Context("Proxy", Label("proxy"), func() {
+		Describe("/v0/backends proxy api", func() {
+			type Backend struct {
+				Host                string `json:"host"`
+				Port                int    `json:"port"`
+				Healthy             bool   `json:"healthy"`
+				Name                string `json:"name"`
+				CurrentSessionCount int    `json:"currentSessionCount"`
+				Active              bool   `json:"active"`
+				TrafficEnabled      bool   `json:"trafficEnabled"`
+			}
+
+			It("reports the backend name with the full BOSH instance/uuid name", func() {
+				req, err := http.NewRequest(http.MethodPost, "http://"+proxyHost+":8080/v0/backends", nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				proxyPassword, err := credhub.GetCredhubPassword("/" + deploymentName + "/cf_mysql_proxy_api_password")
+				Expect(err).NotTo(HaveOccurred())
+				req.SetBasicAuth("proxy", proxyPassword)
+				req.Header.Set("X-Forwarded-Proto", "https")
+
+				res, err := httpClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(res.StatusCode).To(Equal(http.StatusOK), `Expected 200 OK but got %q`, res.Status)
+
+				body, _ := io.ReadAll(res.Body)
+				var backends []Backend
+				Expect(json.Unmarshal(body, &backends)).To(Succeed())
+				Expect(len(backends)).To(Equal(3))
+
+				instances, err := bosh.Instances(deploymentName, bosh.MatchByInstanceGroup("mysql"))
+				for _, i := range instances {
+					name := i.Instance
+					Expect(backends).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal(name),
+					})))
+				}
+			})
 		})
 	})
 })


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
> What does this PR change?  

This PR changes the proxy configuration to always name the backend based on the instance group and UUID in the form "$INSTANCE_GROUP_NAME/$UUID" that can be more trivially copy and pasted into other bosh commands when troubleshooting.

# Motivation
> Tell us about the problem you are facing, with context, that this PR solves.

Currently the proxy dashboard and api reports the MySQL backend a proxy is routing traffic to as "backend-INDEX".  This is not always straight-forward to map to a specific MySQL vm.   The motivation is to precisely report the mysql/UUID the proxy is treating as a backend and if marked unhealthy or having a high number of connection it is easier to find the specific MySQL instance to investigate.

# Related Issue
> If this PR was first opened as an issue, please provide the link to that issue here.

