### PR TITLE
Feature/wsrep applier thread cpu count 184480367

### DIFF
--- a/jobs/pxc-mysql/spec
+++ b/jobs/pxc-mysql/spec
@@ -309,7 +309,6 @@ properties:
     default: 1073741824
   engine_config.galera.wsrep_applier_threads:
       description: 'Defines the number of threads to use when applying replicated write-sets.'
-      default: 1
 
   logging.format.timestamp:
     description: |

--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -40,14 +40,18 @@ log_replica_updates             = ON
 binlog_expire_logs_seconds      = <%= p('engine_config.binlog.expire_logs_days')*24*60*60 %>
 source_verify_checksum          = ON
 <%- if p('engine_config.galera.enabled') -%>
-wsrep_applier_threads           = <%= p('engine_config.galera.wsrep_applier_threads') %>
+<%- if_p("engine_config.galera.wsrep_applier_threads") do |wsrep_applier_threads| -%>
+wsrep_applier_threads           = <%= wsrep_applier_threads %>
+<%- end -%>
 wsrep_provider                  = /var/vcap/packages/percona-xtradb-cluster-8.0/lib/libgalera_smm.so
 <%- end -%>
 
 [mysqld-5.7]
 <%- if p('engine_config.galera.enabled') -%>
 wsrep_sst_auth                  = <%= p('admin_username')%>:<%= p('admin_password') %>
-wsrep_slave_threads             = <%= p('engine_config.galera.wsrep_applier_threads') %>
+<%- if_p("engine_config.galera.wsrep_applier_threads") do |wsrep_applier_threads| -%>
+wsrep_slave_threads             = <%= wsrep_applier_threads %>
+<%- end -%>
 wsrep_provider                  = /var/vcap/packages/percona-xtradb-cluster-5.7/lib/libgalera_smm.so
 <%- end -%>
 log_slave_updates               = ON

--- a/spec/pxc-mysql/mycnf_spec.rb
+++ b/spec/pxc-mysql/mycnf_spec.rb
@@ -207,8 +207,12 @@ describe 'my.cnf template' do
       expect(rendered_template).not_to include("enforce_gtid_consistency = ON")
     end
 
-    it 'defaults Galera applier threads to 1' do
-      expect(rendered_template).to match(/wsrep_applier_threads\s+= 1/)
+    it 'defaults to no wsrep_applier_threads for mysql 8.0' do
+      expect(rendered_template).not_to include("wsrep_applier_threads")
+    end
+
+    it 'defaults to no wsrep_slave_threads for mysql 5.7' do
+      expect(rendered_template).not_to include("wsrep_slave_threads")
     end
 
     context 'engine_config.galera.wsrep_applier_threads is explicitly configured' do
@@ -225,6 +229,10 @@ describe 'my.cnf template' do
 
       it 'configures wsrep_applier_threads to that value' do
         expect(rendered_template).to match(/wsrep_applier_threads\s+= 32/)
+      end
+
+      it 'configures wsrep_slave_threads to that value' do
+        expect(rendered_template).to match(/wsrep_slave_threads\s+= 32/)
       end
     end
 

--- a/src/generate-auto-tune-mysql/auto_tune_generator.go
+++ b/src/generate-auto-tune-mysql/auto_tune_generator.go
@@ -10,20 +10,27 @@ import (
 
 const binlogBlockSize = 4 * 1024
 
-func Generate(totalMem, totalDiskinKB uint64, targetPercentageofMem, targetPercentageofDisk float64, writer io.Writer) error {
+type GenerateValues struct {
+	TotalMem               uint64
+	TotalDiskinKB          uint64
+	TargetPercentageofMem  float64
+	TargetPercentageofDisk float64
+}
 
-	bufferPoolSize := float64(totalMem) * targetPercentageofMem / 100.0
+func Generate(values GenerateValues, writer io.Writer) error {
+
+	bufferPoolSize := float64(values.TotalMem) * values.TargetPercentageofMem / 100.0
 
 	params := []string{}
 	params = append(params, fmt.Sprintf("innodb_buffer_pool_size = %d", uint64(bufferPoolSize)))
 
-	if targetPercentageofDisk != 0.0 {
-		totalDisk := totalDiskinKB * 1024
-		binLogSpaceLimit := float64(totalDisk) * targetPercentageofDisk / 100.0
+	if values.TargetPercentageofDisk != 0.0 {
+		totalDisk := values.TotalDiskinKB * 1024
+		binLogSpaceLimit := float64(totalDisk) * values.TargetPercentageofDisk / 100.0
 		params = append(params, fmt.Sprintf("binlog_space_limit = %d", uint64(binLogSpaceLimit)))
 
-		maxBinlogSize := min(int64(binLogSpaceLimit / 3), 1024*1024*1024)
-		maxBinlogSize = (maxBinlogSize/binlogBlockSize)*binlogBlockSize
+		maxBinlogSize := min(int64(binLogSpaceLimit/3), 1024*1024*1024)
+		maxBinlogSize = (maxBinlogSize / binlogBlockSize) * binlogBlockSize
 
 		params = append(params, fmt.Sprintf("max_binlog_size = %d", uint64(maxBinlogSize)))
 	}

--- a/src/generate-auto-tune-mysql/auto_tune_generator.go
+++ b/src/generate-auto-tune-mysql/auto_tune_generator.go
@@ -15,6 +15,7 @@ type GenerateValues struct {
 	TotalDiskinKB          uint64
 	TargetPercentageofMem  float64
 	TargetPercentageofDisk float64
+	NumCPUs                int
 }
 
 func Generate(values GenerateValues, writer io.Writer) error {
@@ -34,6 +35,12 @@ func Generate(values GenerateValues, writer io.Writer) error {
 
 		params = append(params, fmt.Sprintf("max_binlog_size = %d", uint64(maxBinlogSize)))
 	}
+
+	params = append(params, fmt.Sprintf("[mysqld-8.0]"))
+	params = append(params, fmt.Sprintf("wsrep_applier_threads = %d", values.NumCPUs))
+
+	params = append(params, fmt.Sprintf("[mysqld-5.7]"))
+	params = append(params, fmt.Sprintf("wsrep_slave_threads = %d", values.NumCPUs))
 
 	config := "\n[mysqld]\n" + strings.Join(params, "\n") + "\n"
 	_, err := writer.Write([]byte(config))

--- a/src/generate-auto-tune-mysql/auto_tune_generator_test.go
+++ b/src/generate-auto-tune-mysql/auto_tune_generator_test.go
@@ -3,7 +3,8 @@ package main_test
 import (
 	"bytes"
 	"errors"
-	. "github.com/cloudfoundry/generate-auto-tune-mysql"
+
+	generateAutoTuneMysql "github.com/cloudfoundry/generate-auto-tune-mysql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -37,61 +38,58 @@ innodb_buffer_pool_size = 84
 var _ = Describe("AutoTuneGenerator", func() {
 	Describe("Generate", func() {
 		var (
-			totalMem               uint64
-			totalDiskinKB          uint64
-			targetPercentageofMem  float64
-			targetPercentageofDisk float64
+			values generateAutoTuneMysql.GenerateValues
 		)
 
 		BeforeEach(func() {
-			totalMem = uint64(200)
-			totalDiskinKB = uint64(2 * 1024 * 1024)
-			targetPercentageofMem = float64(42)
-			targetPercentageofDisk = float64(10)
+			values.TotalMem = uint64(200)
+			values.TotalDiskinKB = uint64(2 * 1024 * 1024)
+			values.TargetPercentageofMem = float64(42)
+			values.TargetPercentageofDisk = float64(10)
 		})
 
 		It("writes file with correct parameters", func() {
 			writer := &bytes.Buffer{}
-			Expect(Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, writer)).To(Succeed())
+			Expect(generateAutoTuneMysql.Generate(values, writer)).To(Succeed())
 			Expect(writer.String()).To(Equal(sampleConfig1))
 		})
 
 		Context("when the calculations result in floating numbers", func() {
 			BeforeEach(func() {
-				totalMem = uint64(10)
-				totalDiskinKB = uint64(12345678)
-				targetPercentageofMem = float64(66)
-				targetPercentageofDisk = float64(17)
+				values.TotalMem = uint64(10)
+				values.TotalDiskinKB = uint64(12345678)
+				values.TargetPercentageofMem = float64(66)
+				values.TargetPercentageofDisk = float64(17)
 			})
 
 			It("floors floating numbers to whole integers of bytes", func() {
 				writer := &bytes.Buffer{}
-				Expect(Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, writer)).To(Succeed())
+				Expect(generateAutoTuneMysql.Generate(values, writer)).To(Succeed())
 				Expect(writer.String()).To(Equal(sampleConfig2))
 			})
 		})
 
 		Context("when using binlog space limit is more than 3GB", func() {
 			BeforeEach(func() {
-				totalDiskinKB = uint64(10 * 1024 * 1024)
-				targetPercentageofDisk = float64(50)
+				values.TotalDiskinKB = uint64(10 * 1024 * 1024)
+				values.TargetPercentageofDisk = float64(50)
 			})
 
 			It("sets the maximum binlog file size to 1GB", func() {
 				writer := &bytes.Buffer{}
-				Expect(Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, writer)).To(Succeed())
+				Expect(generateAutoTuneMysql.Generate(values, writer)).To(Succeed())
 				Expect(writer.String()).To(Equal(sampleConfig3))
 			})
 		})
 
 		Context("when using the default target percentage of disk of 0", func() {
 			BeforeEach(func() {
-				targetPercentageofDisk = 0.0
+				values.TargetPercentageofDisk = 0.0
 			})
 
 			It("does not set binlog parameters", func() {
 				writer := &bytes.Buffer{}
-				Expect(Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, writer)).To(Succeed())
+				Expect(generateAutoTuneMysql.Generate(values, writer)).To(Succeed())
 				Expect(writer.String()).To(Equal(sampleConfig4))
 			})
 		})
@@ -99,7 +97,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 		Context("when writing the config file fails", func() {
 			It("returns an error", func() {
 				writer := FailingWriter{}
-				err := Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, writer)
+				err := generateAutoTuneMysql.Generate(values, writer)
 				Expect(err).To(MatchError(`failed to emit mysql configuration: write failed`))
 			})
 		})

--- a/src/generate-auto-tune-mysql/auto_tune_generator_test.go
+++ b/src/generate-auto-tune-mysql/auto_tune_generator_test.go
@@ -14,6 +14,10 @@ var sampleConfig1 = `
 innodb_buffer_pool_size = 84
 binlog_space_limit = 214748364
 max_binlog_size = 71581696
+[mysqld-8.0]
+wsrep_applier_threads = 3
+[mysqld-5.7]
+wsrep_slave_threads = 3
 `
 
 var sampleConfig2 = `
@@ -21,6 +25,10 @@ var sampleConfig2 = `
 innodb_buffer_pool_size = 6
 binlog_space_limit = 2149135626
 max_binlog_size = 716378112
+[mysqld-8.0]
+wsrep_applier_threads = 3
+[mysqld-5.7]
+wsrep_slave_threads = 3
 `
 
 var sampleConfig3 = `
@@ -28,11 +36,19 @@ var sampleConfig3 = `
 innodb_buffer_pool_size = 84
 binlog_space_limit = 5368709120
 max_binlog_size = 1073741824
+[mysqld-8.0]
+wsrep_applier_threads = 3
+[mysqld-5.7]
+wsrep_slave_threads = 3
 `
 
 var sampleConfig4 = `
 [mysqld]
 innodb_buffer_pool_size = 84
+[mysqld-8.0]
+wsrep_applier_threads = 3
+[mysqld-5.7]
+wsrep_slave_threads = 3
 `
 
 var _ = Describe("AutoTuneGenerator", func() {
@@ -46,6 +62,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 			values.TotalDiskinKB = uint64(2 * 1024 * 1024)
 			values.TargetPercentageofMem = float64(42)
 			values.TargetPercentageofDisk = float64(10)
+			values.NumCPUs = 3
 		})
 
 		It("writes file with correct parameters", func() {
@@ -60,6 +77,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 				values.TotalDiskinKB = uint64(12345678)
 				values.TargetPercentageofMem = float64(66)
 				values.TargetPercentageofDisk = float64(17)
+				values.NumCPUs = 3
 			})
 
 			It("floors floating numbers to whole integers of bytes", func() {
@@ -73,6 +91,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 			BeforeEach(func() {
 				values.TotalDiskinKB = uint64(10 * 1024 * 1024)
 				values.TargetPercentageofDisk = float64(50)
+				values.NumCPUs = 3
 			})
 
 			It("sets the maximum binlog file size to 1GB", func() {
@@ -85,6 +104,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 		Context("when using the default target percentage of disk of 0", func() {
 			BeforeEach(func() {
 				values.TargetPercentageofDisk = 0.0
+				values.NumCPUs = 3
 			})
 
 			It("does not set binlog parameters", func() {

--- a/src/generate-auto-tune-mysql/main.go
+++ b/src/generate-auto-tune-mysql/main.go
@@ -9,32 +9,32 @@ import (
 	sigar "github.com/cloudfoundry/gosigar"
 )
 
-var (
-	targetPercentageofMem float64
-	targetPercentageofDisk float64
-	outputFile string
-)
-
 func main() {
-	flag.Float64Var(&targetPercentageofMem, "P", 50.0,
-			"Set this to an integer which represents the percentage of system RAM to reserve for InnoDB's buffer pool")
-	flag.Float64Var(&targetPercentageofDisk, "D", 0,
+	var (
+		outputFile string
+		values     GenerateValues
+	)
+
+	flag.Float64Var(&values.TargetPercentageofMem, "P", 50.0,
+		"Set this to an integer which represents the percentage of system RAM to reserve for InnoDB's buffer pool")
+	flag.Float64Var(&values.TargetPercentageofDisk, "D", 0,
 		"Set this to an integer which represents the percentage of disk to limit how much space is used by binary logs")
 	flag.StringVar(&outputFile, "f", "",
-		       "Target file for rendering MySQL option file")
+		"Target file for rendering MySQL option file")
 	flag.Parse()
 
-
 	mem := sigar.Mem{}
+	//cpuList := sigar.CpuList{}
+	//cpuCount := len(cpuList.List)
 	mem.Get()
-	totalMem := mem.Total
+	values.TotalMem = mem.Total
 
 	fsu := sigar.FileSystemUsage{}
 	fsu.Get("/var/vcap/store/")
-	totalDiskinKB := fsu.Total
+	values.TotalDiskinKB = fsu.Total
 
-	fmt.Printf("%s Total memory in bytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), totalMem)
-	fmt.Printf("%s Total disk in kilobytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), totalDiskinKB)
+	fmt.Printf("%s Total memory in bytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), values.TotalMem)
+	fmt.Printf("%s Total disk in kilobytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), values.TotalDiskinKB)
 
 	file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
@@ -42,7 +42,7 @@ func main() {
 	}
 	defer file.Close()
 
-	if err := Generate(totalMem, totalDiskinKB, targetPercentageofMem, targetPercentageofDisk, file); err != nil {
+	if err := Generate(values, file); err != nil {
 		fmt.Printf("%s generating %s failed: %s\n",
 			time.Now().UTC().Format(time.RFC3339Nano), outputFile, err)
 		os.Exit(1)

--- a/src/generate-auto-tune-mysql/main.go
+++ b/src/generate-auto-tune-mysql/main.go
@@ -24,17 +24,29 @@ func main() {
 	flag.Parse()
 
 	mem := sigar.Mem{}
-	//cpuList := sigar.CpuList{}
-	//cpuCount := len(cpuList.List)
-	mem.Get()
+	err := mem.Get()
+	if err != nil {
+		fmt.Printf("Error returned from mem.Get(): %s", err.Error())
+	}
 	values.TotalMem = mem.Total
+
+	cpuList := sigar.CpuList{}
+	cpuList.Get()
+	if err != nil {
+		fmt.Printf("Error returned from cpuList.Get(): %s", err.Error())
+	}
+	values.NumCPUs = len(cpuList.List)
 
 	fsu := sigar.FileSystemUsage{}
 	fsu.Get("/var/vcap/store/")
+	if err != nil {
+		fmt.Printf("Error returned from fsu.Get(\"/var/vcap/store/\"): %s", err.Error())
+	}
 	values.TotalDiskinKB = fsu.Total
 
 	fmt.Printf("%s Total memory in bytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), values.TotalMem)
 	fmt.Printf("%s Total disk in kilobytes: %d\n", time.Now().UTC().Format(time.RFC3339Nano), values.TotalDiskinKB)
+	fmt.Printf("%s Num cores: %d\n", time.Now().UTC().Format(time.RFC3339Nano), values.NumCPUs)
 
 	file, err := os.OpenFile(outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {


### PR DESCRIPTION
Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
wsrep_applier_threads and wsrep_slave_threads default to number of CPU cores

# Motivation
Customers have observed better performance when the wsrep_applier_threads value is set to a number that is equal to the CPU cores, rather than a static value
