### PR TITLE
Update tool directories with go:build directives

### DIFF
--- a/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/tools/tools.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 

--- a/src/github.com/cloudfoundry-incubator/cf-mysql-cluster-health-logger/tools/tools.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-cluster-health-logger/tools/tools.go
@@ -1,3 +1,5 @@
+//go:build tools
+
 package tools
 
 import (

--- a/src/github.com/cloudfoundry-incubator/galera-healthcheck/tools/tools.go
+++ b/src/github.com/cloudfoundry-incubator/galera-healthcheck/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 

--- a/src/github.com/cloudfoundry-incubator/switchboard/tools/tools.go
+++ b/src/github.com/cloudfoundry-incubator/switchboard/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 

--- a/src/github.com/cloudfoundry/galera-init/tools/tools.go
+++ b/src/github.com/cloudfoundry/galera-init/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 

--- a/src/migrate-to-pxc/tools/tools.go
+++ b/src/migrate-to-pxc/tools/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 


### PR DESCRIPTION
- Added new directive to cf-mysql-cluster-health-logger
- Modified other packages' existing "+build" directives to the newer "go:build" directive (introduced in go 1.17: https://pkg.go.dev/cmd/go#hdr-Build_constraints).

[#185650988](https://www.pivotaltracker.com/story/show/185650988)

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
What does this PR change? 

Improve golang identification of build tool packages

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

- Exclude previously-unlabeled tool directories from "go vet"-ing
- Discontinue use of older "+build" directive in favor of go v1.17-introduced "go:build" 

# Related Issue
If this PR was first opened as an issue, please provide the link to that issue here.

