### PR TITLE
Bump to Percona XtraDB Cluster and Percona XtraBackup to v8.0.34

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem 'bosh-template'
 gem 'rspec'
+gem 'iniparse'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     bosh-template (2.4.0)
       semi_semantic (~> 1.2.0)
     diff-lcs (1.5.0)
+    iniparse (1.5.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -13,10 +14,10 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
     semi_semantic (1.2.0)
 
 PLATFORMS
@@ -24,6 +25,7 @@ PLATFORMS
 
 DEPENDENCIES
   bosh-template
+  iniparse
   rspec
 
 BUNDLED WITH

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ Percona-XtraDB-Cluster-5.7.43-31.65.tar.gz:
   size: 74207772
   object_id: 20509b41-c90d-46ad-4f89-f236deac7760
   sha: sha256:3b5396b46a0335223b33d28430f389340eeeb5719cb3353d50af9a7bd0c7da1d
-Percona-XtraDB-Cluster-8.0.33-25.tar.gz:
-  size: 475611489
-  object_id: 6f1df049-9f28-46f8-54b2-8dcd0779d121
-  sha: sha256:35d60266790b819a16f9586ac6b6685b44c28417aa661963868403c5d2052687
+Percona-XtraDB-Cluster-8.0.34-26.tar.gz:
+  size: 477520512
+  object_id: 68d17724-b645-4006-64f2-17ca1250f1f8
+  sha: sha256:50bdb1646d76d6a3b2cae7d7a4bcbf1087b7c5a05062443300610a631dd5fa9a
 boost_1_59_0.tar.bz2:
   size: 70389425
   object_id: 7344fc77-b911-45c2-5467-c6d5fcab6d29
@@ -30,10 +30,10 @@ percona-xtrabackup-2.4.28.tar.gz:
   size: 62525343
   object_id: 5b8b1630-ef95-4728-4aa6-2bf0df02d080
   sha: sha256:1d77f920a0cf536e12ddcd3a154583b1b52cd3db35bd2d06db629cc255367cea
-percona-xtrabackup-8.0.33-28.tar.gz:
-  size: 447847772
-  object_id: 9daa6f98-e74e-4534-5665-96b7f1cfa470
-  sha: sha256:fa3c5963bf52e7eb99e1178d3db133f9eb224125c36b81710ce69e48c49478da
+percona-xtrabackup-8.0.34-29.tar.gz:
+  size: 449348930
+  object_id: dff552cb-083a-4c79-693c-f6a064af9c52
+  sha: sha256:3a6f7077db8489eb00f25ad01daeaed4fa087100068fac79215c7d2e10424f87
 procps_3.3.17.orig.tar.xz:
   size: 1008428
   object_id: 49ca152b-47d2-4737-5f55-154159b7ed7d

--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -45,6 +45,7 @@ wsrep_applier_threads           = <%= wsrep_applier_threads %>
 <%- end -%>
 wsrep_provider                  = /var/vcap/packages/percona-xtradb-cluster-8.0/lib/libgalera_smm.so
 <%- end -%>
+log-error-suppression-list      = ER_SERVER_WARN_DEPRECATED
 
 [mysqld-5.7]
 <%- if p('engine_config.galera.enabled') -%>
@@ -196,7 +197,6 @@ ssl-key=/var/vcap/jobs/pxc-mysql/certificates/galera-key.pem
 sockopt="cipher=ECDHE-RSA-AES256-GCM-SHA384"
 
 [mysqldump]
-quick
 max_allowed_packet              = <%= p('engine_config.max_allowed_packet') %>
 
 [mysql]


### PR DESCRIPTION
- Bumps Percona-XtraDB-Cluster to v8.0.34-26
- Bumps Percona-XtraBackup to v8.0.34-29
- Adds log-error-suppression-list = ER_SERVER_WARN_DEPRECATED to prevent excessive logging from MySQL v8.0.34's deprecation of the mysql_native_password plugin which is still widely used

[#186387217](https://www.pivotaltracker.com/story/show/186387217)