### PR TITLE
specify log_bin to OFF when binlog.enabled property is set to false.

### DIFF
--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -125,6 +125,8 @@ local_infile                    = <%= bool_to_on_off(p('engine_config.local_infi
 
 <%- if p('engine_config.binlog.enabled') -%>
 log_bin                         = mysql-bin
+<%- else -%>
+skip-log-bin
 <%- end -%>
 relay_log                       = mysql-relay
 relay_log_recovery              = OFF

--- a/operations/disable-binlog.yml
+++ b/operations/disable-binlog.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/engine_config?/binlog?/enabled?
+  value: false


### PR DESCRIPTION
# Feature or Bug Description
In xtradb5.7, binary logs were disable by default. Since xtradb8.0 , they are now enabled by default.

# Motivation
Do not activate binary logs if the property `binlog.enabled` is set to false.

# Related Issue
https://github.com/cloudfoundry/pxc-release/issues/50

