### PR TITLE
Add pxc-mysql job property to disable check for persistent storage

### DIFF
--- a/jobs/pxc-mysql/spec
+++ b/jobs/pxc-mysql/spec
@@ -69,6 +69,9 @@ properties:
   pxc_enabled:
     description: 'Used for disabling the job. Useful if co-locating the cf-mysql release mysql job and migrating'
     default: true
+  disable_persistent_storage_safety_check:
+    description: 'pre-start checks that /var/vcap/store is a persistent volume to prevent accidentally running the database on an ephemeral disk. This can be used to disable this check for test or bosh-lite situations'
+    default: false
 
 
   # Admin Users

--- a/jobs/pxc-mysql/templates/pre-start.sh.erb
+++ b/jobs/pxc-mysql/templates/pre-start.sh.erb
@@ -123,7 +123,9 @@ function check_mysql_disk_capacity() {
   fi
 }
 
+<%- unless p('disable_persistent_storage_safety_check') -%>
 check_mysql_disk_persistence
+<%- end -%>
 check_mysql_disk_capacity
 
 # move the datadir

--- a/spec/pxc-mysql/pre_start_spec.rb
+++ b/spec/pxc-mysql/pre_start_spec.rb
@@ -23,4 +23,15 @@ describe 'galera-agent-config template' do
       expect(rendered_template).to_not include("apply_pxc57_crash_recovery")
     end
   end
+
+  describe 'disable_persistent_storage_safety_check' do
+    it 'leaves the safety check on by default' do
+      expect(rendered_template).to match(/^check_mysql_disk_persistence/)
+    end
+
+    it 'removes the safety check when disabled' do
+      spec['disable_persistent_storage_safety_check'] = true
+      expect(rendered_template).to_not match(/^check_mysql_disk_persistence/)
+    end
+  end
 end


### PR DESCRIPTION
# Feature or Bug Description

Add pxc-mysql job property to disable check for persistent storage

# Motivation

We ran into a problem where this check was blocking deployment when trying to deploy cf-deployment in a bosh-lite situation with the docker-cpi running inside of another docker container.

The device id seems to be the same in that situation even though the docker cpi is creating separate volume mounts into the container.

