### PR TITLE
auto-tune: refactor to use text/template library

### DIFF
--- a/src/generate-auto-tune-mysql/auto_tune_generator_test.go
+++ b/src/generate-auto-tune-mysql/auto_tune_generator_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 
-	generateAutoTuneMysql "github.com/cloudfoundry/generate-auto-tune-mysql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	gomegaformat "github.com/onsi/gomega/format"
+
+	generateAutoTuneMysql "github.com/cloudfoundry/generate-auto-tune-mysql"
 )
 
 var sampleConfig1 = `
@@ -58,6 +60,7 @@ var _ = Describe("AutoTuneGenerator", func() {
 		)
 
 		BeforeEach(func() {
+			gomegaformat.TruncatedDiff = false
 			values.TotalMem = uint64(200)
 			values.TotalDiskinKB = uint64(2 * 1024 * 1024)
 			values.TargetPercentageofMem = float64(42)
@@ -126,6 +129,6 @@ var _ = Describe("AutoTuneGenerator", func() {
 
 type FailingWriter struct{}
 
-func (FailingWriter) Write(p []byte) (n int, err error) {
+func (FailingWriter) Write(_ []byte) (n int, err error) {
 	return -1, errors.New("write failed")
 }

--- a/src/generate-auto-tune-mysql/go.mod
+++ b/src/generate-auto-tune-mysql/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/cloudfoundry/gosigar v1.3.92
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	github.com/pkg/errors v0.9.1
 )
 
 require (
@@ -17,6 +16,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20250501235452-c0086092b71a // indirect
 	github.com/kr/pretty v0.2.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect


### PR DESCRIPTION
While reviewing this to understand the story better, I noticed that we could simplify creating the cnf file by using the text/template package

This feels a little more clear about what's happening compared to hacking together the strings as it was done before

The only gotcha - we need to use hyphens, "-", to clean up whitespace and make sure we don't accidentally add newlines. But the existing tests drove this out

[TNZ-36064](https://jira.eng.vmware.com/browse/TNZ-36064)

Authored-by: Ryan Wittrup <ryan.wittrup@broadcom.com>

