### PR TITLE
Bump default innodb_doublewrite_pages to 128 for MySQL 8.0

### DIFF
--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -207,6 +207,7 @@ innodb_log_file_size            = <%= p('engine_config.innodb_log_file_size')%>M
 innodb_stats_on_metadata        = ON
 innodb_stats_persistent         = OFF
 innodb_strict_mode              = <%= bool_to_on_off(p('engine_config.innodb_strict_mode')) %>
+innodb-doublewrite-pages        = 128
 
 max_connections                 = <%= p('engine_config.max_connections') %>
 


### PR DESCRIPTION
This addresses a regression observed in MySQL 8.0.  For more context refer to this blog post:

https://jfg-mysql.blogspot.com/2025/04/performance-regression-in-mysql-80-fixed-in-84-easy-workaround.html

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
What does this PR change?  

This increases the default value of an option in the MySQL data engine to improve performance for certain write bound workloads.

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

This address a performance regression relative to MySQL 5.7 and aligns with the upcoming MySQL 8.4 release.