### PR TITLE
Introduce percona-xtrabackup-8.4 job

### DIFF
--- a/jobs/percona-xtrabackup-8.4/spec
+++ b/jobs/percona-xtrabackup-8.4/spec
@@ -1,0 +1,9 @@
+---
+name: percona-xtrabackup-8.4
+
+templates: {}
+
+packages:
+- percona-xtrabackup-8.4
+
+properties: {}


### PR DESCRIPTION
This job does nothing but install xtrabackup packages, the same way pxc-release does.

Instance groups include these jobs to ensure percona binaries are available for backup / restore purposes.

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
What does this PR change?  

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

This aligns with jobs that were added in the past, percona-xtrabackup-2.4 (for MySQL v5.7 support) or percona-xtrabackup-8.0 (for MySQl v8.0 support).

This is not directly used by pxc-release but useful for including in bosh manifests that want to make the Percona XtraBackup utility available outside of the MySQL VMs for various troubleshooting or backup / restore purposes.

# Related Issue
If this PR was first opened as an issue, please provide the link to that issue here.

