### PR TITLE
Adds missing unit tests to test-unit script

### DIFF
--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -22,6 +22,16 @@ echo -e "\n>>>>>>>> Testing Bootstrapper..."
 echo -e "\n>>>>>>>> Testing Cluster Health Logger..."
 "${RELEASE_DIR}/src/github.com/cloudfoundry-incubator/cf-mysql-cluster-health-logger/bin/test" "$@"
 
+echo -e "\n>>>>>>>> Testing Generate Auto-Tune MySQL..."
+pushd "${RELEASE_DIR}/src/generate-auto-tune-mysql"
+  go run github.com/onsi/ginkgo/v2/ginkgo -v
+popd
+
+echo -e "\n>>>>>>>> Testing GRA Log Purger..."
+pushd "${RELEASE_DIR}/src/gra-log-purger"
+  go run github.com/onsi/ginkgo/v2/ginkgo -v
+popd
+
 pushd ${RELEASE_DIR}
 bundle install
 bundle exec rspec ./spec

--- a/src/gra-log-purger/gra_log_purger_test.go
+++ b/src/gra-log-purger/gra_log_purger_test.go
@@ -1,7 +1,9 @@
 package main_test
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -164,18 +166,20 @@ var _ = Describe("PurgeGraLogs", func() {
 		)
 
 		BeforeEach(func() {
-			tempFileFd, err = ioutil.TempFile(tempDir, "not-a-directory")
+			tempFileFd, err = os.CreateTemp(tempDir, "not-a-directory")
 			Expect(err).NotTo(HaveOccurred())
 			tempFile = tempFileFd.Name()
 		})
 
 		AfterEach(func() {
-			os.Remove(tempFile)
+			_ = os.Remove(tempFile)
 		})
 
-		It("returns an out of sandbox error", func() {
+		It("returns an error", func() {
 			_, _, err := PurgeGraLogs(tempFile, timeFormat, time.Hour*24*2)
-			Expect(err).To(BeAssignableToTypeOf(&os.SyscallError{}))
+
+			var pathError *fs.PathError
+			Expect(errors.As(err, &pathError)).To(BeTrue(), "should return fs.PathError, but got %#v", err)
 		})
 	})
 })


### PR DESCRIPTION
For gra-log-purger, we also had to fix a test that was failing based on a new error type returned when treating a file as a directory

[TNZ-22697](https://vmw-jira.broadcom.net/browse/TNZ-22697)

Authored-by: Ryan Wittrup <ryan.wittrup@broadcom.com>

