### PR TITLE
Allow mysql-backup user to query binlog events

### DIFF
--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -26,7 +26,7 @@ DROP USER IF EXISTS 'roadmin'@'<%= host %>';
 <%- if_p('mysql_backup_password') do |password| -%>
 CREATE USER IF NOT EXISTS '<%= p('mysql_backup_username') %>'@'localhost';
 ALTER USER '<%= p('mysql_backup_username') %>'@'localhost' IDENTIFIED WITH mysql_native_password BY '<%= password %>';
-GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to '<%= p('mysql_backup_username') %>'@'localhost';
+GRANT RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to '<%= p('mysql_backup_username') %>'@'localhost';
 <%- if p('mysql_version') != "5.7" -%>
 GRANT SELECT on performance_schema.keyring_component_status to '<%= p('mysql_backup_username') %>'@'localhost';
 GRANT SELECT ON performance_schema.log_status TO '<%= p('mysql_backup_username') %>'@'localhost';

--- a/spec/pxc-mysql/golden/db_init_all_features
+++ b/spec/pxc-mysql/golden/db_init_all_features
@@ -14,7 +14,7 @@ DROP USER IF EXISTS 'roadmin'@'%';
 
 CREATE USER IF NOT EXISTS 'mysql-backup'@'localhost';
 ALTER USER 'mysql-backup'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-backup-pw';
-GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to 'mysql-backup'@'localhost';
+GRANT RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to 'mysql-backup'@'localhost';
 GRANT SELECT on performance_schema.keyring_component_status to 'mysql-backup'@'localhost';
 GRANT SELECT ON performance_schema.log_status TO 'mysql-backup'@'localhost';
 

--- a/spec/pxc-mysql/golden/db_init_all_features_mysql57
+++ b/spec/pxc-mysql/golden/db_init_all_features_mysql57
@@ -14,7 +14,7 @@ DROP USER IF EXISTS 'roadmin'@'%';
 
 CREATE USER IF NOT EXISTS 'mysql-backup'@'localhost';
 ALTER USER 'mysql-backup'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-backup-pw';
-GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to 'mysql-backup'@'localhost';
+GRANT RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to 'mysql-backup'@'localhost';
 
 CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
 ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';


### PR DESCRIPTION
This is useful for cases where the mysql-backup user may be archiving binary logs either remotely or by inspecting events via the SHOW BINLOG EVENTS administrative SQL command.

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
What does this PR change?  

Adds the `REPLICATION SLAVE` privilege to the optional `mysql-backup` user.

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

Desire to stream binary logs using the `mysql-backup` user, but facing privilege limitations for accessing this feature.

# Related Issue
If this PR was first opened as an issue, please provide the link to that issue here.

