### PR TITLE
Fix go1.25 go vet and other minor cleanups

### DIFF
--- a/src/github.com/cloudfoundry-incubator/galera-healthcheck/config/config_test.go
+++ b/src/github.com/cloudfoundry-incubator/galera-healthcheck/config/config_test.go
@@ -6,8 +6,9 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
+	"strconv"
 
 	"code.cloudfoundry.org/tlsconfig/certtest"
 	. "github.com/onsi/ginkgo/v2"
@@ -150,11 +151,11 @@ var _ = Describe("Config", func() {
 					errCh <- err
 				}()
 
-				address := fmt.Sprintf("%s:%d", rootConfig.Host, rootConfig.Port)
+				address := net.JoinHostPort(rootConfig.Host, strconv.Itoa(rootConfig.Port))
 				conn, err := net.Dial("tcp", address)
 				Expect(err).NotTo(HaveOccurred())
 
-				msg, err := ioutil.ReadAll(conn)
+				msg, err := io.ReadAll(conn)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(msg)).To(Equal("foo"))
 				Expect(conn.Close()).To(Succeed())

--- a/src/github.com/cloudfoundry/galera-init/cluster_health_checker/cluster_health_checkerfakes/fake_cluster_health_checker.go
+++ b/src/github.com/cloudfoundry/galera-init/cluster_health_checker/cluster_health_checkerfakes/fake_cluster_health_checker.go
@@ -78,8 +78,6 @@ func (fake *FakeClusterHealthChecker) HealthyClusterReturnsOnCall(i int, result1
 func (fake *FakeClusterHealthChecker) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.healthyClusterMutex.RLock()
-	defer fake.healthyClusterMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/cluster_health_checker/cluster_health_checkerfakes/fake_url_getter.go
+++ b/src/github.com/cloudfoundry/galera-init/cluster_health_checker/cluster_health_checkerfakes/fake_url_getter.go
@@ -93,8 +93,6 @@ func (fake *FakeUrlGetter) GetReturnsOnCall(i int, result1 *http.Response, resul
 func (fake *FakeUrlGetter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getMutex.RLock()
-	defer fake.getMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/db_helper/db_helperfakes/fake_dbhelper.go
+++ b/src/github.com/cloudfoundry/galera-init/db_helper/db_helperfakes/fake_dbhelper.go
@@ -306,16 +306,6 @@ func (fake *FakeDBHelper) StopMysqldCalls(stub func()) {
 func (fake *FakeDBHelper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.isDatabaseReachableMutex.RLock()
-	defer fake.isDatabaseReachableMutex.RUnlock()
-	fake.isProcessRunningMutex.RLock()
-	defer fake.isProcessRunningMutex.RUnlock()
-	fake.startMysqldInBootstrapMutex.RLock()
-	defer fake.startMysqldInBootstrapMutex.RUnlock()
-	fake.startMysqldInJoinMutex.RLock()
-	defer fake.startMysqldInJoinMutex.RUnlock()
-	fake.stopMysqldMutex.RLock()
-	defer fake.stopMysqldMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/os_helper/os_helperfakes/fake_os_helper.go
+++ b/src/github.com/cloudfoundry/galera-init/os_helper/os_helperfakes/fake_os_helper.go
@@ -584,22 +584,6 @@ func (fake *FakeOsHelper) WriteStringToFileReturnsOnCall(i int, result1 error) {
 func (fake *FakeOsHelper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.fileExistsMutex.RLock()
-	defer fake.fileExistsMutex.RUnlock()
-	fake.killCommandMutex.RLock()
-	defer fake.killCommandMutex.RUnlock()
-	fake.readFileMutex.RLock()
-	defer fake.readFileMutex.RUnlock()
-	fake.runCommandMutex.RLock()
-	defer fake.runCommandMutex.RUnlock()
-	fake.sleepMutex.RLock()
-	defer fake.sleepMutex.RUnlock()
-	fake.startCommandMutex.RLock()
-	defer fake.startCommandMutex.RUnlock()
-	fake.waitForCommandMutex.RLock()
-	defer fake.waitForCommandMutex.RUnlock()
-	fake.writeStringToFileMutex.RLock()
-	defer fake.writeStringToFileMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/start_manager/node_starter/node_starterfakes/fake_starter.go
+++ b/src/github.com/cloudfoundry/galera-init/start_manager/node_starter/node_starterfakes/fake_starter.go
@@ -161,10 +161,6 @@ func (fake *FakeStarter) StartNodeFromStateReturnsOnCall(i int, result1 string, 
 func (fake *FakeStarter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getMysqlCmdMutex.RLock()
-	defer fake.getMysqlCmdMutex.RUnlock()
-	fake.startNodeFromStateMutex.RLock()
-	defer fake.startNodeFromStateMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/start_manager/start_managerfakes/fake_service_status.go
+++ b/src/github.com/cloudfoundry/galera-init/start_manager/start_managerfakes/fake_service_status.go
@@ -78,8 +78,6 @@ func (fake *FakeServiceStatus) StartReturnsOnCall(i int, result1 error) {
 func (fake *FakeServiceStatus) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.startMutex.RLock()
-	defer fake.startMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/src/github.com/cloudfoundry/galera-init/start_manager/start_managerfakes/fake_start_manager.go
+++ b/src/github.com/cloudfoundry/galera-init/start_manager/start_managerfakes/fake_start_manager.go
@@ -116,10 +116,6 @@ func (fake *FakeStartManager) ShutdownCalls(stub func()) {
 func (fake *FakeStartManager) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.executeMutex.RLock()
-	defer fake.executeMutex.RUnlock()
-	fake.shutdownMutex.RLock()
-	defer fake.shutdownMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Minor testing cleanups motivated by changes in go@1.25 vet tooling that failed on a test file in galera-healthcheck while running the test-unit script.

Also committed some regenerated fakes that were rebuilt by the testing scripts - apparently a previous bump in counterfeiter slightly changed the fakes output.