### PR TITLE
Allows users to be created with defined auth plugins

### DIFF
--- a/jobs/pxc-mysql/spec
+++ b/jobs/pxc-mysql/spec
@@ -147,6 +147,7 @@ properties:
           host: any
           role: schema-admin
           schema: "app-db"
+          auth_plugin: caching_sha2_password
         app-user-with-wildcard-db-access:
           password: "((wildcard_app_user_password))"
           host: any
@@ -367,6 +368,9 @@ properties:
           early-plugin-load: keyring_file.so
           keyring_file_data: /var/vcap/store/pxc-mysql/keyring
 
+  engine_config.user_authentication_policy:
+    description: Authentication plugin for identifying all created users
+    default: 'mysql_native_password'
   logging.format.timestamp:
     description: |
       Format for timestamp in component logs. Valid values are 'rfc3339', 'unix-epoch'. 'rfc3339' is the recommended

--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -25,7 +25,7 @@ DROP USER IF EXISTS 'roadmin'@'<%= host %>';
 <%- end -%>
 <%- if_p('mysql_backup_password') do |password| -%>
 CREATE USER IF NOT EXISTS '<%= p('mysql_backup_username') %>'@'localhost';
-ALTER USER '<%= p('mysql_backup_username') %>'@'localhost' IDENTIFIED WITH mysql_native_password BY '<%= password %>';
+ALTER USER '<%= p('mysql_backup_username') %>'@'localhost' IDENTIFIED WITH <%= p('engine_config.user_authentication_policy') %> BY '<%= password %>';
 GRANT RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to '<%= p('mysql_backup_username') %>'@'localhost';
 <%- if p('mysql_version') != "5.7" -%>
 GRANT SELECT on performance_schema.keyring_component_status to '<%= p('mysql_backup_username') %>'@'localhost';
@@ -34,13 +34,13 @@ GRANT SELECT ON performance_schema.log_status TO '<%= p('mysql_backup_username')
 
 <%- end -%>
 <%- hosts.each do |host| -%>
-CREATE USER IF NOT EXISTS '<%= p('admin_username') %>'@'<%= host %>' IDENTIFIED WITH mysql_native_password BY '<%= p('admin_password') %>';
-ALTER USER '<%= p('admin_username') %>'@'<%= host %>' IDENTIFIED WITH mysql_native_password BY '<%= p('admin_password') %>';
+CREATE USER IF NOT EXISTS '<%= p('admin_username') %>'@'<%= host %>' IDENTIFIED WITH <%= p('engine_config.user_authentication_policy') %> BY '<%= p('admin_password') %>';
+ALTER USER '<%= p('admin_username') %>'@'<%= host %>' IDENTIFIED WITH <%= p('engine_config.user_authentication_policy') %> BY '<%= p('admin_password') %>';
 GRANT ALL PRIVILEGES ON *.* TO '<%= p('admin_username') %>'@'<%= host %>' WITH GRANT OPTION;
   <%- if p('roadmin_enabled') -%>
 
-CREATE USER IF NOT EXISTS 'roadmin'@'<%= host %>' IDENTIFIED WITH mysql_native_password BY '<%= p('roadmin_password') %>';
-ALTER USER 'roadmin'@'<%= host %>' IDENTIFIED WITH mysql_native_password BY '<%= p('roadmin_password') %>';
+CREATE USER IF NOT EXISTS 'roadmin'@'<%= host %>' IDENTIFIED WITH <%= p('engine_config.user_authentication_policy') %> BY '<%= p('roadmin_password') %>';
+ALTER USER 'roadmin'@'<%= host %>' IDENTIFIED WITH <%= p('engine_config.user_authentication_policy') %> BY '<%= p('roadmin_password') %>';
 GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'roadmin'@'<%= host %>';
   <%- end -%>
 
@@ -53,10 +53,10 @@ GRANT SELECT, PROCESS, REPLICATION CLIENT ON *.* TO 'roadmin'@'<%= host %>';
     end
     %{
 CREATE USER IF NOT EXISTS #{user['username']}@#{user['host']}
-  IDENTIFIED WITH mysql_native_password BY #{user['password']}
+  IDENTIFIED WITH #{user['auth_plugin']} BY #{user['password']}
   #{max_user_clause}/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER #{user['username']}@#{user['host']}
-  IDENTIFIED WITH mysql_native_password BY #{user['password']}
+  IDENTIFIED WITH #{user['auth_plugin']} BY #{user['password']}
   #{max_user_clause}/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 }.strip
   end
@@ -142,6 +142,13 @@ REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
     if cfg['role'].nil? || cfg['role'].empty?
       raise("seeded_users property specifies an empty allowed 'role' for username #{username}")
     end
+    if cfg['auth_plugin'].nil? || cfg['auth_plugin'].empty?
+      cfg['auth_plugin'] = p('engine_config.user_authentication_policy')
+    else
+      unless %w[mysql_native_password caching_sha2_password].include? cfg['auth_plugin']
+        raise "seeded_users property specifies unsupported authentication plugin '#{cfg['auth_plugin']}' for user '#{username}'"
+      end
+    end
 
     mysql_host = case cfg['host']
                  when "localhost" then "localhost"
@@ -157,6 +164,7 @@ REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
       "password" => escape(cfg['password']),
       "schema" => cfg['schema'],
       "role" => cfg["role"],
+      "auth_plugin" => cfg["auth_plugin"],
       "max_user_connections" => cfg["max_user_connections"],
     }.compact
   end
@@ -189,7 +197,8 @@ REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
       "role" => "schema-admin",
       "password" => e["password"],
       "host" => "any",
-      "schema" => e["name"]
+      "schema" => e["name"],
+      "auth_plugin" => e["auth_plugin"],
     }]
   }.to_h.merge(p('seeded_users')).sort.to_h
 
@@ -198,6 +207,7 @@ REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
       "role" => "minimal",
       "password" => link.p('db_password'),
       "host" => "localhost",
+      "auth_plugin" => p('engine_config.user_authentication_policy'),
     }
   end
 
@@ -206,6 +216,7 @@ REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
       "role" => "minimal",
       "password" => link.p('db_password'),
       "host" => "localhost",
+      "auth_plugin" => p('engine_config.user_authentication_policy'),
     }
   end
 

--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -59,7 +59,7 @@ socket                          = <%= "#{base_folder}/mysqld.sock" %>
 <%# Re-enable mysql_native_password authentication plugin for backwards compatibility %>
 mysql-native-password           = ON
 
-authentication-policy           = mysql_native_password
+authentication-policy           = <%= p('engine_config.user_authentication_policy') %>
 mysqlx_socket                   = <%= "#{base_folder}/mysqlx.sock" %>
 log_replica_updates             = ON
 binlog_expire_logs_seconds      = <%= p('engine_config.binlog.expire_logs_days')*24*60*60 %>
@@ -77,7 +77,7 @@ jemalloc-profiling              = ON
 
 [<%= section = 'mysqld-8.0' %>]
 innodb-doublewrite-pages        = 128
-authentication-policy           = mysql_native_password
+authentication-policy           = <%= p('engine_config.user_authentication_policy') %>
 mysqlx_socket                   = <%= "#{base_folder}/mysqlx.sock" %>
 log_replica_updates             = ON
 binlog_expire_logs_seconds      = <%= p('engine_config.binlog.expire_logs_days')*24*60*60 %>

--- a/jobs/pxc-mysql/templates/pre-start.sh.erb
+++ b/jobs/pxc-mysql/templates/pre-start.sh.erb
@@ -10,6 +10,12 @@ set -o pipefail
   end
 -%>
 
+<%-
+  unless %w[mysql_native_password caching_sha2_password].include? p('engine_config.user_authentication_policy')
+    raise "Unsupported value '#{p('engine_config.user_authentication_policy')}' for 'engine_config.user_authentication_policy' property. Choose from 'mysql_native_password' or 'caching_sha2_password'"
+  end
+-%>
+
 mysql_version="<%=p('mysql_version')%>"
 
 ## NOTE: This script MUST ALWAYS run as root user.

--- a/operations/test/seed-generic-user.yml
+++ b/operations/test/seed-generic-user.yml
@@ -1,0 +1,15 @@
+---
+- path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/seeded_users?/generic-user?
+  type: replace
+  value:
+    role: schema-admin
+    schema: generic_db
+    host: any
+    password: ((generic_user_password))
+    auth_plugin: caching_sha2_password
+
+- type: replace
+  path: /variables/name=generic_user_password?
+  value:
+    name: generic_user_password
+    type: password

--- a/operations/test/sysbench-user.yml
+++ b/operations/test/sysbench-user.yml
@@ -5,6 +5,7 @@
     name: sbtest
     username: sbtest
     password: ((sysbench_db_password))
+    auth_plugin: caching_sha2_password
 
 - type: replace
   path: /variables/name=sysbench_db_password?

--- a/spec/pxc-mysql/golden/db_init_all_features
+++ b/spec/pxc-mysql/golden/db_init_all_features
@@ -13,38 +13,38 @@ DROP USER IF EXISTS 'root'@'%';
 DROP USER IF EXISTS 'roadmin'@'%';
 
 CREATE USER IF NOT EXISTS 'mysql-backup'@'localhost';
-ALTER USER 'mysql-backup'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-backup-pw';
+ALTER USER 'mysql-backup'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'secret-backup-pw';
 GRANT RELOAD, LOCK TABLES, REPLICATION SLAVE, REPLICATION CLIENT, /*!80001 BACKUP_ADMIN,*/ PROCESS ON *.* to 'mysql-backup'@'localhost';
 GRANT SELECT on performance_schema.keyring_component_status to 'mysql-backup'@'localhost';
 GRANT SELECT ON performance_schema.log_status TO 'mysql-backup'@'localhost';
 
-CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
 
-CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
 
-CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'::1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'::1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;
 
 -- user: 'basic-user'@'localhost' role: minimal
 CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
-  IDENTIFIED WITH mysql_native_password BY 'secret-basic-user-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'basic-user'@'localhost'
-  IDENTIFIED WITH mysql_native_password BY 'secret-basic-user-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
@@ -57,10 +57,10 @@ DROP PREPARE stmt;
 
 -- user: 'multi-schema-admin-user'@'%' role: multi-schema-admin
 CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-multi-schema-admin-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'multi-schema-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-multi-schema-admin-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
@@ -68,10 +68,10 @@ REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
 -- user: 'mysql-metrics'@'%' role: mysql-metrics
 CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-mysql-metrics-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'mysql-metrics'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-mysql-metrics-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
@@ -83,10 +83,10 @@ DROP PREPARE stmt;
 
 -- user: 'special-admin-user'@'%' role: admin
 CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;

--- a/spec/pxc-mysql/golden/db_init_all_features_mysql57
+++ b/spec/pxc-mysql/golden/db_init_all_features_mysql57
@@ -39,10 +39,10 @@ REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
@@ -81,10 +81,10 @@ DROP PREPARE stmt;
 
 -- user: 'special-admin-user'@'%' role: admin
 CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;

--- a/spec/pxc-mysql/golden/db_init_no_mysqlbackup
+++ b/spec/pxc-mysql/golden/db_init_no_mysqlbackup
@@ -12,33 +12,33 @@ DROP USER IF EXISTS 'roadmin'@'::1';
 DROP USER IF EXISTS 'root'@'%';
 DROP USER IF EXISTS 'roadmin'@'%';
 
-CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
 
-CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'127.0.0.1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION;
 
-CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
-ALTER USER 'root'@'::1' IDENTIFIED WITH mysql_native_password BY 'secret-admin-pw';
+CREATE USER IF NOT EXISTS 'root'@'::1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
+ALTER USER 'root'@'::1' IDENTIFIED WITH caching_sha2_password BY 'secret-admin-pw';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'::1' WITH GRANT OPTION;
 
 -- user: 'basic-user'@'localhost' role: minimal
 CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
-  IDENTIFIED WITH mysql_native_password BY 'secret-basic-user-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'basic-user'@'localhost'
-  IDENTIFIED WITH mysql_native_password BY 'secret-basic-user-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'cloud_controller'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-ccdb-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
@@ -51,10 +51,10 @@ DROP PREPARE stmt;
 
 -- user: 'multi-schema-admin-user'@'%' role: multi-schema-admin
 CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-multi-schema-admin-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'multi-schema-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-multi-schema-admin-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
@@ -62,10 +62,10 @@ REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
 -- user: 'mysql-metrics'@'%' role: mysql-metrics
 CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-mysql-metrics-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'mysql-metrics'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-mysql-metrics-db-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
@@ -77,10 +77,10 @@ DROP PREPARE stmt;
 
 -- user: 'special-admin-user'@'%' role: admin
 CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 ALTER USER 'special-admin-user'@'%'
-  IDENTIFIED WITH mysql_native_password BY 'secret-seeded-admin-pw'
+  IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;


### PR DESCRIPTION
To support transition from mysql_native_password to caching_sha2_password

Some of the core users are explicitly set to use the new plugin

For externally defined users, via both seeded_users and seeded_databases, a new property is supported for 'plugin' - this will allow consumers to define when they want to make the migration

MySQL team can open a PR to TPCF to set the properties for all the users we create for the platform, and this lets us opt out individual users if we find an application doesn't support the new plugin yet

For consumers that do not define an explicit plugin for a given user, this currently defaults to sticking with mysql_native_password to allow for backwards compatibility - maybe we flip this in the next PXC release?

WIP todo's
- review the rest of the "core" users
- is there a good way to test creating user with mysql_native_password and then see that's updated on redeploy? aka is there a good cheap way

[TNZ-56365](https://vmw-jira.broadcom.net/browse/TNZ-56365)

Authored-by: Ryan Wittrup <ryan.wittrup@broadcom.com>

Thanks for opening a PR. Please make sure you've read and followed the [Contributing guide](https://github.com/cloudfoundry-incubator/pxc-release/blob/master/README.md#contribution-guide), including signing the Contributor License Agreement.

# Feature or Bug Description
What does this PR change?  

# Motivation
Tell us about the problem you are facing, with context, that this PR solves.

# Related Issue
If this PR was first opened as an issue, please provide the link to that issue here.

