### PR TITLE
Fix failing system tests

### DIFF
--- a/operations/default-auth-plugin.yml
+++ b/operations/default-auth-plugin.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/engine_config?/user_authentication_policy?
+  value: ((auth_plugin))

--- a/operations/test/seed-generic-user.yml
+++ b/operations/test/seed-generic-user.yml
@@ -6,7 +6,7 @@
     schema: generic_db
     host: any
     password: ((generic_user_password))
-    auth_plugin: caching_sha2_password
+    auth_plugin: ((auth_plugin))
 
 - type: replace
   path: /variables/name=generic_user_password?

--- a/operations/test/smoke-tests-use-legacy-auth.yml
+++ b/operations/test/smoke-tests-use-legacy-auth.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/seeded_users/smoke-tests-user/auth_plugin?
+  value: mysql_native_password

--- a/operations/test/sysbench-user-set-auth-plugin.yml
+++ b/operations/test/sysbench-user-set-auth-plugin.yml
@@ -1,0 +1,4 @@
+---
+- type: replace
+  path: /instance_groups/name=mysql/jobs/name=pxc-mysql/properties/seeded_databases?/name=sbtest?/auth_plugin?
+  value: ((auth_plugin))


### PR DESCRIPTION
The recently merged PR to make the MySQL auth plugin configurable failed under MySQL v5.7 because caching_sha2_password was hardcoded in various test fixtures.

This change makes the auth plugin more dynamic and falls back to safer defaults or skips tests under a MySQL v5.7 configuration.

Additionally this will set the global default auth plugin to caching_sha2_password under MySQL v8.0 or later to gain further confidence this feature was plumbed through correctly.