### PR TITLE
Start pxc-mysql in pre-start w/ best-effort

### DIFF
--- a/jobs/pxc-mysql/templates/pre-start.sh.erb
+++ b/jobs/pxc-mysql/templates/pre-start.sh.erb
@@ -155,6 +155,9 @@ chown -R vcap:vcap ${datadir}
 
 rm -f /etc/my.cnf
 
+check_bpm_pid() {
+    /var/vcap/jobs/bpm/bin/bpm pid pxc-mysql -p galera-init >/dev/null 2>&1
+}
 
 is_pxc57_datadir() {
   [[ -f /var/vcap/store/pxc-mysql/mysql/user.frm ]]
@@ -185,4 +188,23 @@ if is_pxc80_datadir; then
   apply_pxc80_crash_recovery
 fi
 
+# start mysql early and validate it comes online
+# This is best effort: if mysql fails to start here
+# (because the cluster is unhealthy) then the bosh lifecycle will continue
+# and be caught by the pxc-mysql post-start implementation which will fail
+# if the node is in an unhealthy state.
+if /var/vcap/jobs/bpm/bin/bpm start pxc-mysql -p galera-init; then
+  while ! curl -s -f -m 5 http://127.0.0.1:8114 > /dev/null && check_bpm_pid; do
+      sleep 1
+  done
+
+  if ! check_bpm_pid; then
+    log "pre-start: galera-init failed to start"
+  else
+    log "pre-start: galera-init started successfully"
+  fi
+
+else
+  log "pre-start: galera-init failed to initialize"
+fi
 <% end %>


### PR DESCRIPTION
If pxc-mysql fails to start, the post-start will capture a deploy failure.

This resolve an issue with certain MySQL VM sidecars that may expect MySQL to online by the time "start" or "post-start" runs.
