### PR TITLE
Bump socat to v1.8.1.1

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -50,7 +50,7 @@ procps-ng-4.0.5.tar.xz:
   size: 1517672
   object_id: e196e815-f7be-462d-64f0-feaac1caffe0
   sha: sha256:c2e6d193cc78f84cd6ddb72aaf6d5c6a9162f0470e5992092057f5ff518562fa
-socat-1.7.4.4.tar.gz:
-  size: 662968
-  object_id: beda2a1f-82fe-4370-47c9-080352292869
-  sha: sha256:0f8f4b9d5c60b8c53d17b60d79ababc4a0f51b3bb6d2bd3ae8a6a4b9d68f195e
+socat-1.8.1.1.tar.bz2:
+  size: 606348
+  object_id: e42ede18-244d-423f-6f34-da9f0b08748e
+  sha: sha256:5ebc636b7f427053f98806696521653a614c7e06464910353cbf54e2327adc1b

--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -46,7 +46,7 @@ install_runtime_dependencies() {
     ln -sf "/var/vcap/packages/percona-xtrabackup-${version}" "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-${version}"
   done
 
-  tar -xf socat-*.tar.gz
+  tar -xf socat-*.tar.bz2
   cd socat-*/
   ./configure "--prefix=${BOSH_INSTALL_TARGET}"
   make -j "$(nproc)" install

--- a/packages/percona-xtradb-cluster-8.0/spec
+++ b/packages/percona-xtradb-cluster-8.0/spec
@@ -9,4 +9,4 @@ files:
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
 - pkg-config_*.tar.gz
-- socat-*.tar.gz
+- socat-*.tar.bz2

--- a/packages/percona-xtradb-cluster-8.4/packaging
+++ b/packages/percona-xtradb-cluster-8.4/packaging
@@ -46,7 +46,7 @@ install_runtime_dependencies() {
     ln -sf "/var/vcap/packages/percona-xtrabackup-${version}" "${BOSH_INSTALL_TARGET}/bin/pxc_extra/pxb-${version}"
   done
 
-  tar -xf socat-*.tar.gz
+  tar -xf socat-*.tar.bz2
   cd socat-*/
   ./configure "--prefix=${BOSH_INSTALL_TARGET}"
   make -j "$(nproc)" install

--- a/packages/percona-xtradb-cluster-8.4/spec
+++ b/packages/percona-xtradb-cluster-8.4/spec
@@ -9,4 +9,4 @@ files:
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
 - pkg-config_*.tar.gz
-- socat-*.tar.gz
+- socat-*.tar.bz2


### PR DESCRIPTION
Bump socat to v1.8.1.1

Sourced from: http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.bz2
Verified via: [Debian source control: socat_1.8.1.1-1.dsc](https://deb.debian.org/debian/pool/main/s/socat/socat_1.8.1.1-1.dsc) using key `7D887DC8BA7BBBA7B835E3BADCE310E7864CC8BF`
Digest: `sha256:5ebc636b7f427053f98806696521653a614c7e06464910353cbf54e2327adc1b`
Project checksum: http://www.dest-unreach.org/socat/download.sha256sum

# Feature Description

Bumps the socat utility used by Percona XtraDB Cluster packages as part of state transfer orchestration.

# Motivation

* Address compilation failures on experimental ubuntu-resolute stemcells.
* Patch CVE-2024-54661 and update OpenSSL integration to use modern, non-deprecated API calls. 
   This mitigates CVE scan alerts for a low-risk vulnerability in functionality (socat readline) not utilized by pxc-release.
* Adds support for TLS v1.3 for SST
* Improves reliability in IPv6 or dual-stack networking environments via improved address resolution logic

# Related Issue

Extracted from the larger PR #102 for easier review.
