### PR TITLE
Stub Percona Xtrabackup v2.4

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,6 @@ Percona-XtraDB-Cluster-8.4.7-7.tar.gz:
   size: 506738352
   object_id: 46238cf5-2ca3-4619-47d2-e54bf1d2f418
   sha: sha256:5b8e7c4d4cb422d018ec668d9cc69f6f403e4974ea71a6d7405a8b2194aa14a9
-boost_1_59_0.tar.bz2:
-  size: 70389425
-  object_id: 7344fc77-b911-45c2-5467-c6d5fcab6d29
-  sha: sha256:727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca
 boost_1_77_0.tar.bz2:
   size: 110361537
   object_id: d962752f-1ab7-4896-41d9-8deed29397ca
@@ -30,10 +26,6 @@ libev-4.33.tar.gz:
   size: 569527
   object_id: 0ea3b0f6-7b83-4fe5-7ff8-966bcc56ab73
   sha: sha256:507eb7b8d1015fbec5b935f34ebed15bf346bed04a11ab82b8eee848c4205aea
-percona-xtrabackup-2.4.29.tar.gz:
-  size: 64667518
-  object_id: f196e2a0-e2ba-43ef-7d91-4319f8e6b927
-  sha: sha256:c59f0d612ec6a0f530ca3645546fb8af690f62d3ecbd70d33f30d3f56d9e842e
 percona-xtrabackup-8.0.35-35.tar.gz:
   size: 447852862
   object_id: cfe465d2-d13b-46a9-64f1-8ebb44bd7e08

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,6 @@ Percona-XtraDB-Cluster-8.4.10-10.tar.gz:
   size: 507260341
   object_id: 775580cb-1bcd-4b93-59db-a2e9c61a3ecd
   sha: sha256:02eecdb76572704967788fb090fc62d8acfdc6a474f85c9cbfb22e9db0942945
-boost_1_59_0.tar.bz2:
-  size: 70389425
-  object_id: 7344fc77-b911-45c2-5467-c6d5fcab6d29
-  sha: sha256:727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca
 boost_1_77_0.tar.bz2:
   size: 110361537
   object_id: d962752f-1ab7-4896-41d9-8deed29397ca
@@ -30,10 +26,6 @@ libev-4.33.tar.gz:
   size: 569527
   object_id: 0ea3b0f6-7b83-4fe5-7ff8-966bcc56ab73
   sha: sha256:507eb7b8d1015fbec5b935f34ebed15bf346bed04a11ab82b8eee848c4205aea
-percona-xtrabackup-2.4.29.tar.gz:
-  size: 64667518
-  object_id: f196e2a0-e2ba-43ef-7d91-4319f8e6b927
-  sha: sha256:c59f0d612ec6a0f530ca3645546fb8af690f62d3ecbd70d33f30d3f56d9e842e
 percona-xtrabackup-8.0.35-36.tar.gz:
   size: 447823107
   object_id: 3a0293d7-787a-4cf4-60c5-83cf1c9a6744

--- a/packages/percona-xtrabackup-2.4/packaging
+++ b/packages/percona-xtrabackup-2.4/packaging
@@ -1,57 +1,20 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
+set -o errexit -o nounset
 
-main() {
-  install_build_dependencies
-  unpack_source
-  build_and_install
-}
+mkdir -p "${BOSH_INSTALL_TARGET}/bin"
+script="${BOSH_INSTALL_TARGET}/bin/xtrabackup"
+cat >"$script" <<'EOF'
+#!/bin/bash
 
-install_build_dependencies() {
-  tar -xf libaio_*.tar.xz
-  cd libaio-*/
-  make -j "$(nproc)" install prefix="${BOSH_INSTALL_TARGET}"
-  cd -
+for arg in "$@";do
+  if [[ $arg == "--version" ]]; then
+    echo "xtrabackup version 2.4.29"
+    exit 0
+  fi
+done
 
-  tar -xf libev-*.tar.gz
-  cd libev-*/
-  ./configure --prefix=/usr/local --disable-static
-  make -j "$(nproc)" install
-  ./configure --prefix="${BOSH_INSTALL_TARGET}" --libdir="${BOSH_INSTALL_TARGET}/lib/private" --disable-static
-  make -j "$(nproc)" install-exec
-  cd -
-}
-
-unpack_source() {
-  tar -xf boost_1_59_0.tar.bz2
-  tar -xf percona-xtrabackup-*.tar.gz
-}
-
-build_and_install() {
-  cd percona-xtrabackup-*/
-  mkdir bld && cd bld
-
-  export LIBRARY_PATH="${BOSH_INSTALL_TARGET}/lib:${BOSH_INSTALL_TARGET}/lib/private"
-  export LD_LIBRARY_PATH="${BOSH_INSTALL_TARGET}/lib"
-  export CPLUS_INCLUDE_PATH="${BOSH_INSTALL_TARGET}/include"
-  export C_INCLUDE_PATH="${BOSH_INSTALL_TARGET}/include"
-
-  # shellcheck disable=SC2016
-  cmake .. \
-    -DBUILD_CONFIG=xtrabackup_release \
-    -DCMAKE_CXX_COMPILER=g++ \
-    -DCMAKE_C_COMPILER=gcc \
-    -DCMAKE_INSTALL_PREFIX="${BOSH_INSTALL_TARGET}" \
-    -DCMAKE_INSTALL_RPATH='$ORIGIN/../lib/private;$ORIGIN/../lib' \
-    -DINSTALL_MYSQLTESTDIR= \
-    -DWITH_BOOST=../../boost_1_59_0 \
-    -DWITH_MAN_PAGES=OFF \
-    -DWITH_SSL=system
-
-  make -j "$(nproc)" install/strip
-  rm -fr "${BOSH_INSTALL_TARGET}/man/"
-}
-
-main
+echo >&2 "MySQL v5.7 is not supported under this configuration."
+exit 1
+EOF
+chmod 0755 "${script}"

--- a/packages/percona-xtrabackup-2.4/spec
+++ b/packages/percona-xtrabackup-2.4/spec
@@ -3,8 +3,4 @@ name: percona-xtrabackup-2.4
 
 dependencies: []
 
-files:
-- boost_1_59_0.tar.bz2
-- percona-xtrabackup-2.4*.tar.gz
-- libev-*.tar.gz
-- libaio_*.tar.xz
+files: []


### PR DESCRIPTION
This completes the removal of all MySQL v5.7 support from the release.

Percona XtraDB Cluster v8.0 still depends on percona-xtrabackup v2.4 _binaries_ and will fail if they are not present.

These old binaries are required _just in case_ the cluster upgrades from a Percona XtraDB Cluster v5.7 version. However, pxc-release explicitly rejects upgrades from old MySQL v5.7 data directories (this transtion should be completed under pxc/1.1.x versions) so percona-xtrabackup is no longer required.

Since the Percona XtraDB Cluster v8.0 wsrep_sst_xtrabackup-v2 script requires the pxb-2.4/bin path to exist, the existing binaries are stubbed with a simple bash script that echos an expected version when the "pxb-2.4/bin/xtrabackup --version" option is passed and fails loudly otherwise.

Removing Percona XtraBackup v2.4 provides two benefits:
- Mitigate CVE scans against EOL software
- Enable compilation support on ubuntu-resolute stemcells without patching GPLv2 Percona XtraBackup v2.4 source.