### PR TITLE
Replace build-dependency pkg-config with pkgconf

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -42,10 +42,10 @@ percona-xtrabackup-8.4.0-5.tar.gz:
   size: 432646274
   object_id: edf66c32-e051-4a55-561a-bd67bb8a13bb
   sha: sha256:fadcf27efd2a2596f689388659e2ff5c36debcc051a55974ac8bb4a83c015f57
-pkg-config_0.29.2.orig.tar.gz:
-  size: 2016830
-  object_id: ca3d829d-016e-4acd-6509-9d1766884b9d
-  sha: sha256:6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591
+pkgconf-2.5.1.tar.xz:
+  size: 328064
+  object_id: 74152211-babf-41d2-794a-2f1abcd5f998
+  sha: sha256:cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243
 procps-ng-4.0.5.tar.xz:
   size: 1517672
   object_id: e196e815-f7be-462d-64f0-feaac1caffe0

--- a/packages/percona-xtrabackup-8.0/packaging
+++ b/packages/percona-xtrabackup-8.0/packaging
@@ -10,12 +10,11 @@ main() {
 }
 
 install_build_dependencies() {
-  tar -xf pkg-config_*.tar.gz
-  cd pkg-config-*/
-  ./configure --prefix=/usr \
-    --with-internal-glib \
-    --with-pc-path=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+  tar -xf pkgconf-*.tar.xz
+  cd pkgconf-*/
+  ./configure --prefix=/usr
   make -j "$(nproc)" install
+  ln -sf pkgconf /usr/bin/pkg-config
   cd -
 
   tar -xf libaio_*.tar.xz

--- a/packages/percona-xtrabackup-8.0/spec
+++ b/packages/percona-xtrabackup-8.0/spec
@@ -8,5 +8,5 @@ files:
 - percona-xtrabackup-8.0*.tar.gz
 - libev-*.tar.gz
 - libaio_*.tar.xz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - procps-ng-*.tar.xz

--- a/packages/percona-xtrabackup-8.4/packaging
+++ b/packages/percona-xtrabackup-8.4/packaging
@@ -10,12 +10,11 @@ main() {
 }
 
 install_build_dependencies() {
-  tar -xf pkg-config_*.tar.gz
-  cd pkg-config-*/
-  ./configure --prefix=/usr \
-    --with-internal-glib \
-    --with-pc-path=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+  tar -xf pkgconf-*.tar.xz
+  cd pkgconf-*/
+  ./configure --prefix=/usr
   make -j "$(nproc)" install
+  ln -sf pkgconf /usr/bin/pkg-config
   cd -
 
   tar -xf libaio_*.tar.xz

--- a/packages/percona-xtrabackup-8.4/spec
+++ b/packages/percona-xtrabackup-8.4/spec
@@ -7,5 +7,5 @@ files:
 - libaio_*.tar.xz
 - libev-*.tar.gz
 - percona-xtrabackup-8.4*.tar.gz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - procps-ng-*.tar.xz

--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -11,13 +11,11 @@ main() {
 }
 
 install_build_dependencies() {
-  tar -xf pkg-config_*.tar.gz
-  cd pkg-config-*/
-  ./configure \
-    --prefix=/usr \
-    --with-internal-glib \
-    --with-pc-path=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+  tar -xf pkgconf-*.tar.xz
+  cd pkgconf-*/
+  ./configure --prefix=/usr
   make -j "$(nproc)" install
+  ln -sf pkgconf /usr/bin/pkg-config
   cd -
 
   tar -xf libaio_*.orig.tar.xz

--- a/packages/percona-xtradb-cluster-8.0/spec
+++ b/packages/percona-xtradb-cluster-8.0/spec
@@ -8,5 +8,5 @@ files:
 - boost_1_77_0.tar.bz2
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - socat-*.tar.bz2

--- a/packages/percona-xtradb-cluster-8.0/spec
+++ b/packages/percona-xtradb-cluster-8.0/spec
@@ -8,5 +8,5 @@ files:
 - boost_1_77_0.tar.bz2
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - socat-*.tar.gz

--- a/packages/percona-xtradb-cluster-8.4/packaging
+++ b/packages/percona-xtradb-cluster-8.4/packaging
@@ -11,13 +11,11 @@ main() {
 }
 
 install_build_dependencies() {
-  tar -xf pkg-config_*.tar.gz
-  cd pkg-config-*/
-  ./configure \
-    --prefix=/usr \
-    --with-internal-glib \
-    --with-pc-path=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
+  tar -xf pkgconf-*.tar.xz
+  cd pkgconf-*/
+  ./configure --prefix=/usr
   make -j "$(nproc)" install
+  ln -sf pkgconf /usr/bin/pkg-config
   cd -
 
   tar -xf libaio_*.orig.tar.xz

--- a/packages/percona-xtradb-cluster-8.4/spec
+++ b/packages/percona-xtradb-cluster-8.4/spec
@@ -8,5 +8,5 @@ files:
 - boost_1_77_0.tar.bz2
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - socat-*.tar.bz2

--- a/packages/percona-xtradb-cluster-8.4/spec
+++ b/packages/percona-xtradb-cluster-8.4/spec
@@ -8,5 +8,5 @@ files:
 - boost_1_77_0.tar.bz2
 - check_*.tar.gz
 - libaio_*.orig.tar.xz
-- pkg-config_*.tar.gz
+- pkgconf-*.tar.xz
 - socat-*.tar.gz


### PR DESCRIPTION
# Feature or Bug Description

Replaces pkg-config with pkgconf

This is largely a drop-in replacement and released under the permissive ISC license (vs. GPLv2 for pkg-config)

See: http://pkgconf.org/features.html

Blob sourced from: https://distfiles.ariadne.space/pkgconf/pkgconf-2.5.1.tar.xz (published the the [pkgconfg project](https://github.com/pkgconf/pkgconf#release-tarballs))
Verified via debian: https://deb.debian.org/debian/pool/main/p/pkgconf/pkgconf_2.5.1-4.dsc (using GPG key id `E8446B4AC8C77261`)
Digest: `sha256:cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243`

# Motivation

This is largely motivated by compatibility with upcoming ubuntu-resolute stemcells

See: https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/497


# Related Issue

Extracted from the larger PR #102 for easier review.