### PR TITLE
Revoke PROXY privilege on seeded user role changes

### DIFF
--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -61,6 +61,7 @@ ALTER USER #{user['username']}@#{user['host']}
 
   def grant_admin_privs(user)
     %{
+#{revoke_all_privileges(user)}
 GRANT ALL PRIVILEGES ON *.* TO #{user['username']}@#{user['host']} WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO #{user['username']}@#{user['host']} WITH GRANT OPTION;
 }.strip
@@ -123,7 +124,8 @@ GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO #{user['username']}@#{user['
 
   def revoke_all_privileges(user)
     %{
-REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM #{user['username']}@#{user['host']};
+REVOKE IF EXISTS PROXY ON ''@'' FROM #{user['username']}@#{user['host']};
 }.strip
   end
 

--- a/spec/integration/internal/docker/docker.go
+++ b/spec/integration/internal/docker/docker.go
@@ -48,10 +48,6 @@ func RunContainer(spec ContainerSpec) string {
 	Expect(err).NotTo(HaveOccurred(),
 		`Failed to create docker container: %s`, err)
 
-	DeferCleanup(func() {
-		_ = RemoveContainer(containerID)
-	})
-
 	StartContainer(containerID)
 
 	return containerID

--- a/spec/integration/user_management_test.go
+++ b/spec/integration/user_management_test.go
@@ -48,8 +48,10 @@ var _ = Describe("UserManagement", Ordered, func() {
 		dbUsers = MySQLJobSpec{}
 	})
 
-	JustBeforeEach(func() {
-		doc, err := json.Marshal(dbUsers)
+	renderDBInit := func(spec MySQLJobSpec) string {
+		GinkgoHelper()
+
+		doc, err := json.Marshal(spec)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp("", "db_init_")
@@ -64,20 +66,26 @@ var _ = Describe("UserManagement", Ordered, func() {
 		GinkgoWriter.Println("$ ./scripts/render-db_init")
 		Expect(cmd.Run()).To(Succeed())
 
+		return f.Name()
+	}
+
+	applyDBInit := func(tag, initFilePath string) string {
+		GinkgoHelper()
+		return startMySQL(tag, []string{"--init-file=/db_init"}, []string{initFilePath + ":/db_init"})
+	}
+
+	JustBeforeEach(func() {
+		initFilePath := renderDBInit(dbUsers)
+
 		// Initialize the data volume first, so our db_init does not interfere with percona's entrypoint bootstrapping
 		resource = startMySQL(mysqlVersionTag, nil, nil)
 		Expect(docker.RemoveContainer(resource)).To(Succeed())
 
-		resource = startMySQL(
-			mysqlVersionTag,
-			[]string{"--init-file=/db_init"},
-			[]string{f.Name() + ":/db_init"},
-		)
+		resource = applyDBInit(mysqlVersionTag, initFilePath)
 		DeferCleanup(func() {
 			if CurrentSpecReport().Failed() {
 				return
 			}
-
 			Expect(docker.RemoveContainer(resource)).To(Succeed())
 			Expect(docker.RemoveVolume(volumeID)).To(Succeed())
 		})
@@ -365,6 +373,83 @@ var _ = Describe("UserManagement", Ordered, func() {
 				"GRANT SELECT ON `performance_schema`.`log_status` TO `mysql-backup`@`localhost`",
 			})
 			verifyMaxUserConnections("mysql-backup", "localhost", 0)
+		})
+	})
+
+	When("a seeded user's role is downgraded across redeploys", func() {
+		var (
+			testUser        = "role-downgrade-user"
+			initialPassword string
+		)
+
+		BeforeEach(func() {
+			initialPassword = uuid.NewString()
+			dbUsers = MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "admin",
+						Password: initialPassword,
+						Host:     "any",
+					},
+				},
+			}
+		})
+
+		It("removes the PROXY privilege when downgraded from admin to minimal", func() {
+			// First deploy: verify the admin user has a PROXY grant.
+			By("verifying the admin user has a PROXY grant after initial deploy")
+			db := docker.MySQLDB(resource)
+			db.SetMaxIdleConns(0)
+			Expect(showGrants(db, testUser, "%")).To(
+				ContainElement(ContainSubstring("PROXY ON")),
+			)
+			Expect(db.Close()).To(Succeed())
+
+			// Second deploy: downgrade the same user@host to minimal role.
+			By("redeploying with the user downgraded to minimal role")
+			Expect(docker.RemoveContainer(resource)).To(Succeed())
+			resource = applyDBInit(mysqlVersionTag, renderDBInit(MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "minimal",
+						Password: uuid.NewString(),
+						Host:     "any",
+					},
+				},
+			}))
+
+			db = docker.MySQLDB(resource)
+			defer func() { _ = db.Close() }()
+			// After downgrade the user should hold only the baseline USAGE grant —
+			// no PROXY, no data privileges, no GRANT OPTION.
+			By("verifying no PROXY grant remains after downgrade")
+			Expect(showGrants(db, testUser, "%")).To(ConsistOf(
+				"GRANT USAGE ON *.* TO `role-downgrade-user`@`%`",
+			))
+		})
+
+		It("removing a non-existent PROXY grant is idempotent (minimal -> minimal)", func() {
+			// First deploy is already minimal here because BeforeEach configures admin,
+			// but we override to minimal to prove the PROXY revoke SQL does not error
+			// when the grant was never issued.
+			By("applying minimal role on a user that never had admin")
+			Expect(docker.RemoveContainer(resource)).To(Succeed())
+			resource = applyDBInit(mysqlVersionTag, renderDBInit(MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "minimal",
+						Password: uuid.NewString(),
+						Host:     "any",
+					},
+				},
+			}))
+
+			By("verifying the user has only USAGE with no PROXY")
+			db := docker.MySQLDB(resource)
+			defer func() { _ = db.Close() }()
+			Expect(showGrants(db, testUser, "%")).To(ConsistOf(
+				"GRANT USAGE ON *.* TO `role-downgrade-user`@`%`",
+			))
 		})
 	})
 })

--- a/spec/pxc-mysql/golden/db_init_all_features
+++ b/spec/pxc-mysql/golden/db_init_all_features
@@ -37,7 +37,8 @@ CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
 ALTER USER 'basic-user'@'localhost'
   IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'basic-user'@'localhost';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'basic-user'@'localhost';
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
@@ -46,7 +47,8 @@ CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
 ALTER USER 'cloud_controller'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'cloud_controller'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'cloud_controller'@'%';
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
 REVOKE LOCK TABLES ON `cloud\_controller`.* FROM 'cloud_controller'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'cloud_controller';
@@ -62,7 +64,8 @@ CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
 ALTER USER 'multi-schema-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'multi-schema-admin-user'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'multi-schema-admin-user'@'%';
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
 REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
@@ -73,7 +76,8 @@ CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
 ALTER USER 'mysql-metrics'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql-metrics'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'mysql-metrics'@'%';
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'metrics_db';
 SET @_sql = IF(@_schema_exists, 'DO 1', 'CREATE SCHEMA `metrics_db` CHARACTER SET ''utf8mb4''');
@@ -88,6 +92,8 @@ CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
 ALTER USER 'special-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'special-admin-user'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'special-admin-user'@'%';
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;
 

--- a/spec/pxc-mysql/golden/db_init_no_mysqlbackup
+++ b/spec/pxc-mysql/golden/db_init_no_mysqlbackup
@@ -31,7 +31,8 @@ CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
 ALTER USER 'basic-user'@'localhost'
   IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'basic-user'@'localhost';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'basic-user'@'localhost';
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
@@ -40,7 +41,8 @@ CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
 ALTER USER 'cloud_controller'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'cloud_controller'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'cloud_controller'@'%';
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
 REVOKE LOCK TABLES ON `cloud\_controller`.* FROM 'cloud_controller'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'cloud_controller';
@@ -56,7 +58,8 @@ CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
 ALTER USER 'multi-schema-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'multi-schema-admin-user'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'multi-schema-admin-user'@'%';
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
 REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
@@ -67,7 +70,8 @@ CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
 ALTER USER 'mysql-metrics'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql-metrics'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'mysql-metrics'@'%';
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'metrics_db';
 SET @_sql = IF(@_schema_exists, 'DO 1', 'CREATE SCHEMA `metrics_db` CHARACTER SET ''utf8mb4''');
@@ -82,6 +86,8 @@ CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
 ALTER USER 'special-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'special-admin-user'@'%';
+REVOKE IF EXISTS PROXY ON ''@'' FROM 'special-admin-user'@'%';
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;
 


### PR DESCRIPTION
# Feature or Bug Description

This change revokes the PROXY privilege from a `seeded_users` managed user when redeploying pxc-release and downgrading the role of a seeded user from `admin` to a lesser privileged role.   Previously the user would retain the admin `PROXY` privilege.

Additionally, adjusted the REVOKE ALL PRIVILEGES syntax to use the MySQL v8.0+ variant:

```sql
REVOKE ALL PRIVILEGES, GRANT OPTION FROM $user
```

This makes is more obvious that all privileges are being revoked.  This is functionality identical to the older `REVOKE ALL PRIVILEGES ON *.* FROM ...` form, and merely updated for clarity.

A change was also made to admin grants to revoke previous privileges before adjusting a new admin user's grant.   This avoids a corner case where redeploying a less role to an admin role retained unnecessary grants (which would be covered by the admin role anyway).    This aligns the admin privilege grants with other types of roles in the `seeded_users` feature.

# Motivation

This addresses an observation that PROXY privilege was retained on an unprivileged after a redeploy that demoted a  user that was previously deployed with `role: admin` user.

None of these issues were problematic in practice.  The PROXY privilege on the anonymous user without a GRANT OPTION confers no special privilege escalation.   The REVOKE ALL syntax change is aesthetic.    Admin users retaining less privileged per-object (e.g. database) grants were not given any additional privileges.   

This change is purely around security hygiene and cleaning up the implementation.
