### PR TITLE
[support/1.1.x] Revoke PROXY privilege on seeded user role changes

### DIFF
--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -63,6 +63,7 @@ ALTER USER #{user['username']}@#{user['host']}
 
   def grant_admin_privs(user)
     %{
+#{revoke_all_privileges(user)}
 GRANT ALL PRIVILEGES ON *.* TO #{user['username']}@#{user['host']} WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO #{user['username']}@#{user['host']} WITH GRANT OPTION;
 }.strip
@@ -125,7 +126,12 @@ GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO #{user['username']}@#{user['
 
   def revoke_all_privileges(user)
     %{
-REVOKE ALL PRIVILEGES ON *.* FROM #{user['username']}@#{user['host']};
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM #{user['username']}@#{user['host']};
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = #{user['username']} AND Host = #{user['host']} AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM #{user['username'].gsub("'", "''")}@#{user['host'].gsub("'", "''")}', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 }.strip
   end
 

--- a/spec/integration/internal/docker/docker.go
+++ b/spec/integration/internal/docker/docker.go
@@ -48,10 +48,6 @@ func RunContainer(spec ContainerSpec) string {
 	Expect(err).NotTo(HaveOccurred(),
 		`Failed to create docker container: %s`, err)
 
-	DeferCleanup(func() {
-		_ = RemoveContainer(containerID)
-	})
-
 	StartContainer(containerID)
 
 	return containerID

--- a/spec/integration/user_management_test.go
+++ b/spec/integration/user_management_test.go
@@ -48,8 +48,10 @@ var _ = Describe("UserManagement", Ordered, func() {
 		dbUsers = MySQLJobSpec{}
 	})
 
-	JustBeforeEach(func() {
-		doc, err := json.Marshal(dbUsers)
+	renderDBInit := func(spec MySQLJobSpec) string {
+		GinkgoHelper()
+
+		doc, err := json.Marshal(spec)
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := os.CreateTemp("", "db_init_")
@@ -64,20 +66,26 @@ var _ = Describe("UserManagement", Ordered, func() {
 		GinkgoWriter.Println("$ ./scripts/render-db_init")
 		Expect(cmd.Run()).To(Succeed())
 
+		return f.Name()
+	}
+
+	applyDBInit := func(tag, initFilePath string) string {
+		GinkgoHelper()
+		return startMySQL(tag, []string{"--init-file=/db_init"}, []string{initFilePath + ":/db_init"})
+	}
+
+	JustBeforeEach(func() {
+		initFilePath := renderDBInit(dbUsers)
+
 		// Initialize the data volume first, so our db_init does not interfere with percona's entrypoint bootstrapping
 		resource = startMySQL(mysqlVersionTag, nil, nil)
 		Expect(docker.RemoveContainer(resource)).To(Succeed())
 
-		resource = startMySQL(
-			mysqlVersionTag,
-			[]string{"--init-file=/db_init"},
-			[]string{f.Name() + ":/db_init"},
-		)
+		resource = applyDBInit(mysqlVersionTag, initFilePath)
 		DeferCleanup(func() {
 			if CurrentSpecReport().Failed() {
 				return
 			}
-
 			Expect(docker.RemoveContainer(resource)).To(Succeed())
 			Expect(docker.RemoveVolume(volumeID)).To(Succeed())
 		})
@@ -369,6 +377,84 @@ var _ = Describe("UserManagement", Ordered, func() {
 				"GRANT SELECT ON `performance_schema`.`log_status` TO `mysql-backup`@`localhost`",
 			})
 			verifyMaxUserConnections("mysql-backup", "localhost", 0)
+		})
+	})
+
+
+	When("a seeded user's role is downgraded across redeploys", func() {
+		var (
+			testUser        = "role-downgrade-user"
+			initialPassword string
+		)
+
+		BeforeEach(func() {
+			initialPassword = uuid.NewString()
+			dbUsers = MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "admin",
+						Password: initialPassword,
+						Host:     "any",
+					},
+				},
+			}
+		})
+
+		It("removes the PROXY privilege when downgraded from admin to minimal", func() {
+			// First deploy: verify the admin user has a PROXY grant.
+			By("verifying the admin user has a PROXY grant after initial deploy")
+			db := docker.MySQLDB(resource)
+			db.SetMaxIdleConns(0)
+			Expect(showGrants(db, testUser, "%")).To(
+				ContainElement(ContainSubstring("PROXY ON")),
+			)
+			Expect(db.Close()).To(Succeed())
+
+			// Second deploy: downgrade the same user@host to minimal role.
+			By("redeploying with the user downgraded to minimal role")
+			Expect(docker.RemoveContainer(resource)).To(Succeed())
+			resource = applyDBInit(mysqlVersionTag, renderDBInit(MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "minimal",
+						Password: uuid.NewString(),
+						Host:     "any",
+					},
+				},
+			}))
+
+			db = docker.MySQLDB(resource)
+			defer func() { _ = db.Close() }()
+			// After downgrade the user should hold only the baseline USAGE grant —
+			// no PROXY, no data privileges, no GRANT OPTION.
+			By("verifying no PROXY grant remains after downgrade")
+			Expect(showGrants(db, testUser, "%")).To(ConsistOf(
+				"GRANT USAGE ON *.* TO `role-downgrade-user`@`%`",
+			))
+		})
+
+		It("removing a non-existent PROXY grant is idempotent (minimal -> minimal)", func() {
+			// First deploy is already minimal here because BeforeEach configures admin,
+			// but we override to minimal to prove the PROXY revoke SQL does not error
+			// when the grant was never issued.
+			By("applying minimal role on a user that never had admin")
+			Expect(docker.RemoveContainer(resource)).To(Succeed())
+			resource = applyDBInit(mysqlVersionTag, renderDBInit(MySQLJobSpec{
+				SeededUsers: map[string]UserRole{
+					testUser: {
+						Role:     "minimal",
+						Password: uuid.NewString(),
+						Host:     "any",
+					},
+				},
+			}))
+
+			By("verifying the user has only USAGE with no PROXY")
+			db := docker.MySQLDB(resource)
+			defer func() { _ = db.Close() }()
+			Expect(showGrants(db, testUser, "%")).To(ConsistOf(
+				"GRANT USAGE ON *.* TO `role-downgrade-user`@`%`",
+			))
 		})
 	})
 

--- a/spec/pxc-mysql/golden/db_init_all_features
+++ b/spec/pxc-mysql/golden/db_init_all_features
@@ -37,7 +37,12 @@ CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
 ALTER USER 'basic-user'@'localhost'
   IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'basic-user'@'localhost';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'basic-user' AND Host = 'localhost' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''basic-user''@''localhost''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
@@ -46,7 +51,12 @@ CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
 ALTER USER 'cloud_controller'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'cloud_controller'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'cloud_controller' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''cloud_controller''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
 REVOKE LOCK TABLES ON `cloud\_controller`.* FROM 'cloud_controller'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'cloud_controller';
@@ -62,7 +72,12 @@ CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
 ALTER USER 'multi-schema-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'multi-schema-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'multi-schema-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''multi-schema-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
 REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
@@ -73,7 +88,12 @@ CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
 ALTER USER 'mysql-metrics'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql-metrics'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'mysql-metrics' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''mysql-metrics''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'metrics_db';
 SET @_sql = IF(@_schema_exists, 'DO 1', 'CREATE SCHEMA `metrics_db` CHARACTER SET ''utf8mb4''');
@@ -88,6 +108,12 @@ CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
 ALTER USER 'special-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'special-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'special-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''special-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;
 

--- a/spec/pxc-mysql/golden/db_init_all_features_mysql57
+++ b/spec/pxc-mysql/golden/db_init_all_features_mysql57
@@ -35,7 +35,12 @@ CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
 ALTER USER 'basic-user'@'localhost'
   IDENTIFIED WITH mysql_native_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'basic-user'@'localhost';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'basic-user' AND Host = 'localhost' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''basic-user''@''localhost''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
@@ -44,7 +49,12 @@ CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
 ALTER USER 'cloud_controller'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'cloud_controller'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'cloud_controller' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''cloud_controller''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
 REVOKE LOCK TABLES ON `cloud\_controller`.* FROM 'cloud_controller'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'cloud_controller';
@@ -60,7 +70,12 @@ CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
 ALTER USER 'multi-schema-admin-user'@'%'
   IDENTIFIED WITH mysql_native_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'multi-schema-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'multi-schema-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''multi-schema-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
 REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
@@ -71,7 +86,12 @@ CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
 ALTER USER 'mysql-metrics'@'%'
   IDENTIFIED WITH mysql_native_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql-metrics'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'mysql-metrics' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''mysql-metrics''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'metrics_db';
 SET @_sql = IF(@_schema_exists, 'DO 1', 'CREATE SCHEMA `metrics_db` CHARACTER SET ''utf8mb4''');
@@ -86,6 +106,12 @@ CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
 ALTER USER 'special-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'special-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'special-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''special-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;
 

--- a/spec/pxc-mysql/golden/db_init_no_mysqlbackup
+++ b/spec/pxc-mysql/golden/db_init_no_mysqlbackup
@@ -31,7 +31,12 @@ CREATE USER IF NOT EXISTS 'basic-user'@'localhost'
 ALTER USER 'basic-user'@'localhost'
   IDENTIFIED WITH caching_sha2_password BY 'secret-basic-user-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'basic-user'@'localhost';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'basic-user'@'localhost';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'basic-user' AND Host = 'localhost' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''basic-user''@''localhost''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 
 -- user: 'cloud_controller'@'%' role: schema-admin
 CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
@@ -40,7 +45,12 @@ CREATE USER IF NOT EXISTS 'cloud_controller'@'%'
 ALTER USER 'cloud_controller'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-ccdb-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'cloud_controller'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'cloud_controller'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'cloud_controller' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''cloud_controller''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `cloud\_controller`.* TO 'cloud_controller'@'%';
 REVOKE LOCK TABLES ON `cloud\_controller`.* FROM 'cloud_controller'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'cloud_controller';
@@ -56,7 +66,12 @@ CREATE USER IF NOT EXISTS 'multi-schema-admin-user'@'%'
 ALTER USER 'multi-schema-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-multi-schema-admin-db-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'multi-schema-admin-user'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'multi-schema-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'multi-schema-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''multi-schema-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON `multi_schemas_%`.* TO 'multi-schema-admin-user'@'%';
 REVOKE LOCK TABLES ON `multi_schemas_%`.* FROM 'multi-schema-admin-user'@'%';
 
@@ -67,7 +82,12 @@ CREATE USER IF NOT EXISTS 'mysql-metrics'@'%'
 ALTER USER 'mysql-metrics'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-mysql-metrics-db-pw'
   WITH MAX_USER_CONNECTIONS 3/*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
-REVOKE ALL PRIVILEGES ON *.* FROM 'mysql-metrics'@'%';
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'mysql-metrics'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'mysql-metrics' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''mysql-metrics''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'mysql-metrics'@'%';
 SELECT COUNT(*) INTO @_schema_exists FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'metrics_db';
 SET @_sql = IF(@_schema_exists, 'DO 1', 'CREATE SCHEMA `metrics_db` CHARACTER SET ''utf8mb4''');
@@ -82,6 +102,12 @@ CREATE USER IF NOT EXISTS 'special-admin-user'@'%'
 ALTER USER 'special-admin-user'@'%'
   IDENTIFIED WITH caching_sha2_password BY 'secret-seeded-admin-pw'
   /*!80001 ATTRIBUTE '{ "pxc-release-seeded-user": true }'*/;
+REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'special-admin-user'@'%';
+SELECT COUNT(*) INTO @_has_proxy_grant FROM mysql.proxies_priv WHERE User = 'special-admin-user' AND Host = '%' AND Proxied_user = '' AND Proxied_host = '';
+SET @_sql = IF(@_has_proxy_grant, 'REVOKE PROXY ON ''''@'''' FROM ''special-admin-user''@''%''', 'DO 1');
+PREPARE stmt FROM @_sql;
+EXECUTE stmt;
+DROP PREPARE stmt;
 GRANT ALL PRIVILEGES ON *.* TO 'special-admin-user'@'%' WITH GRANT OPTION;
 GRANT PROXY ON ''@'' TO 'special-admin-user'@'%' WITH GRANT OPTION;
 


### PR DESCRIPTION
This is a backport of #110 to the support/1.1.x branch.

# Feature or Bug Description

When resetting a seeded user's privileges, also revoke the PROXY grant that the admin role issues.

For MySQL v5.7 compatibility (during late upgrades), uses a prepared statement conditional logic that runs "REVOKE PROXY ..." only if the user has previously been granted that privilege to avoid errors.

Adds a revoke step at the start of grant_admin_privs so any accumulated grants are cleared before admin privileges are re-applied.

Adds integration tests covering admin-to-minimal downgrade and idempotent revoke of a non-existent PROXY grant.

# Motivation

This addresses an observation that PROXY privilege was retained on an unprivileged after a redeploy that demoted a  user that was previously deployed with `role: admin` user.

None of these issues were problematic in practice.  The PROXY privilege on the anonymous user without a GRANT OPTION confers no special privilege escalation.   The REVOKE ALL syntax change is aesthetic.    Admin users retaining less privileged per-object (e.g. database) grants were not given any additional privileges.   

This change is purely around security hygiene and cleaning up the implementation.