### PR TITLE
Configure pkgconf with multiarch pkg-config and library search paths

### DIFF
--- a/packages/percona-xtrabackup-8.0/packaging
+++ b/packages/percona-xtrabackup-8.0/packaging
@@ -12,7 +12,10 @@ main() {
 install_build_dependencies() {
   tar -xf pkgconf-*.tar.xz
   cd pkgconf-*/
-  ./configure --prefix=/usr
+  ./configure \
+    --prefix=/usr \
+    --with-pkg-config-dir=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig \
+    --with-system-libdir=/usr/lib/x86_64-linux-gnu:/usr/lib
   make -j "$(nproc)" install
   ln -sf pkgconf /usr/bin/pkg-config
   cd -

--- a/packages/percona-xtrabackup-8.4/packaging
+++ b/packages/percona-xtrabackup-8.4/packaging
@@ -12,7 +12,10 @@ main() {
 install_build_dependencies() {
   tar -xf pkgconf-*.tar.xz
   cd pkgconf-*/
-  ./configure --prefix=/usr
+  ./configure \
+    --prefix=/usr \
+    --with-pkg-config-dir=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig \
+    --with-system-libdir=/usr/lib/x86_64-linux-gnu:/usr/lib
   make -j "$(nproc)" install
   ln -sf pkgconf /usr/bin/pkg-config
   cd -

--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -13,7 +13,10 @@ main() {
 install_build_dependencies() {
   tar -xf pkgconf-*.tar.xz
   cd pkgconf-*/
-  ./configure --prefix=/usr
+  ./configure \
+    --prefix=/usr \
+    --with-pkg-config-dir=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig \
+    --with-system-libdir=/usr/lib/x86_64-linux-gnu:/usr/lib
   make -j "$(nproc)" install
   ln -sf pkgconf /usr/bin/pkg-config
   cd -

--- a/packages/percona-xtradb-cluster-8.4/packaging
+++ b/packages/percona-xtradb-cluster-8.4/packaging
@@ -13,7 +13,10 @@ main() {
 install_build_dependencies() {
   tar -xf pkgconf-*.tar.xz
   cd pkgconf-*/
-  ./configure --prefix=/usr
+  ./configure \
+    --prefix=/usr \
+    --with-pkg-config-dir=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig \
+    --with-system-libdir=/usr/lib/x86_64-linux-gnu:/usr/lib
   make -j "$(nproc)" install
   ln -sf pkgconf /usr/bin/pkg-config
   cd -


### PR DESCRIPTION
The original pkg-config build included --with-pc-path to search /usr/lib/x86_64-linux-gnu/pkgconfig. When switching to pkgconf, the equivalent --with-pkg-config-dir flag was not included, so pkgconf omitted the multiarch path from its compiled-in defaults.

On ubuntu-noble, cmake 3.28's FindOpenSSL uses pkg-config to resolve the library directory hint. Without openssl.pc visible to pkgconf, cmake could not locate OPENSSL_CRYPTO_LIBRARY despite libssl-dev being installed, causing the percona-xtrabackup builds to fail at the libkmip cmake configure step.

This was a regression introduced by #107 and only visible under ubuntu-noble compilation which was not caught before the merge.