### PR TITLE
Enforce integer validation for seeded users max_user_connections

### DIFF
--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -158,6 +158,14 @@ REVOKE IF EXISTS PROXY ON ''@'' FROM #{user['username']}@#{user['host']};
                    raise "invalid host '#{cfg['host']}' specified for username #{username}"
                  end
 
+    if cfg["max_user_connections"]
+      begin
+        Integer(cfg["max_user_connections"])
+      rescue ArgumentError, TypeError
+        raise "seeded_users property specifies non-integer max_user_connections for username #{username}"
+      end
+    end
+
     {
       "username" => escape(username),
       "host" => escape(mysql_host),
@@ -165,7 +173,7 @@ REVOKE IF EXISTS PROXY ON ''@'' FROM #{user['username']}@#{user['host']};
       "schema" => cfg['schema'],
       "role" => cfg["role"],
       "auth_plugin" => cfg["auth_plugin"],
-      "max_user_connections" => cfg["max_user_connections"],
+      "max_user_connections" => cfg["max_user_connections"] && Integer(cfg["max_user_connections"]),
     }.compact
   end
 

--- a/spec/pxc-mysql/db_init_spec.rb
+++ b/spec/pxc-mysql/db_init_spec.rb
@@ -312,5 +312,25 @@ describe 'db_init template' do
         expect { template.render(spec) }.to raise_error(RuntimeError, "seeded_users property specifies unsupported authentication plugin 'mysql_clear_password' for user 'invalid-auth-plugin'")
       end
     end
+
+    context 'when seeded_users specifies a non-integer max_user_connections' do
+      before(:each) do
+        spec["seeded_users"]["some-user"] = { "role" => "minimal", "password" => "secret", "host" => "any", "max_user_connections" => "0; CREATE USER 'evil'@'%'" }
+      end
+
+      it 'fails' do
+        expect { template.render(spec) }.to raise_error(RuntimeError, "seeded_users property specifies non-integer max_user_connections for username some-user")
+      end
+    end
+
+    context 'when seeded_users specifies max_user_connections as a quoted numeric string' do
+      before(:each) do
+        spec["seeded_users"]["some-user"] = { "role" => "minimal", "password" => "secret", "host" => "any", "max_user_connections" => "32" }
+      end
+
+      it 'renders successfully and coerces the value' do
+        expect(template.render(spec)).to match(/WITH MAX_USER_CONNECTIONS 32/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Validates and coerces the `max_user_connections` property to an integer to prevent potential SQL injection attacks from BOSH manifest values. If an invalid value (like a malicious SQL string) is provided, the template will now raise a clear `RuntimeError`.