### PR TITLE
Fix SQL injection via unescaped backslash in seeded_users password

### DIFF
--- a/jobs/pxc-mysql/templates/db_init.erb
+++ b/jobs/pxc-mysql/templates/db_init.erb
@@ -187,7 +187,7 @@ REVOKE IF EXISTS PROXY ON ''@'' FROM #{user['username']}@#{user['host']};
 }
   end
 
-  def escape(value) "'#{value.gsub("'", "''")}'" end
+  def escape(value) "'#{value.gsub('\\') { '\\\\' }.gsub("'", "''")}'" end
   def ident(value) "`#{value.gsub("`", "``")}`" end
   def ident_escaped(value) "#{ident(value).gsub("_", "\\_").gsub("%", "\\%")}" end
 

--- a/spec/pxc-mysql/db_init_spec.rb
+++ b/spec/pxc-mysql/db_init_spec.rb
@@ -313,4 +313,35 @@ describe 'db_init template' do
       end
     end
   end
+
+  context 'password escaping in seeded_users' do
+    def spec_with_password(pw)
+      {
+        "admin_password" => "secret-admin-pw",
+        "seeded_users" => {
+          "test-user" => { "role" => "minimal", "password" => pw, "host" => "localhost" },
+        }
+      }
+    end
+
+    it 'escapes a backslash in the password' do
+      rendered = template.render(spec_with_password('pass\\word'))
+      expect(rendered).to include("BY 'pass\\\\word'")
+    end
+
+    it 'escapes a single quote in the password' do
+      rendered = template.render(spec_with_password("it's"))
+      expect(rendered).to include("BY 'it''s'")
+    end
+
+    it 'escapes a password ending in a backslash (SQL injection vector)' do
+      rendered = template.render(spec_with_password('secret\\'))
+      expect(rendered).to include("BY 'secret\\\\'")
+    end
+
+    it 'escapes a password containing both a backslash and a single quote' do
+      rendered = template.render(spec_with_password("it\\'s"))
+      expect(rendered).to include("BY 'it\\\\''s'")
+    end
+  end
 end


### PR DESCRIPTION
escape() in db_init.erb used ANSI quote-doubling only; a trailing backslash neutralized the closing quote, allowing arbitrary SQL execution via the init_file on next bosh deploy. Backslashes are now escaped before quotes, and regression tests cover the injection vector and mixed special-character cases.

[TNZ-97935]
ai-assisted=yes