### PR TITLE
TNZ-97928 Redact galera-agent password from bootstrap failure logs

### DIFF
--- a/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/config/config.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	HealthcheckURLs           []string   `yaml:"HealthcheckURLs" validate:"nonzero"`
 	BackendTLS                BackendTLS `yaml:"BackendTLS"`
 	Username                  string     `yaml:"Username" validate:"nonzero"`
-	Password                  string     `yaml:"Password" validate:"nonzero"`
+	Password                  string     `yaml:"Password" validate:"nonzero" json:"-"`
 	ShutDownMysql             string
 	MysqlStatus               string
 	GetSeqNumber              string
@@ -28,7 +28,7 @@ type Config struct {
 type BackendTLS struct {
 	Enabled            bool   `yaml:"Enabled"`
 	ServerName         string `yaml:"ServerName"`
-	CA                 string `yaml:"CA"`
+	CA                 string `yaml:"CA" json:"-"`
 	InsecureSkipVerify bool   `yaml:"InsecureSkipVerify"`
 }
 

--- a/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/config/config_test.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"encoding/json"
 	"fmt"
 
 	. "github.com/cloudfoundry-incubator/cf-mysql-bootstrap/config"
@@ -86,6 +87,30 @@ var _ = Describe("Config", func() {
 			rootConfig.RepairMode = "shoestrap"
 			err := rootConfig.Validate()
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Sensitive field redaction", func() {
+		BeforeEach(func() {
+			rawConfig = `{
+			"HealthcheckURLs": ["http://10.10.10.10:9200"],
+			"Username": "fake-username",
+			"Password": "fake-password",
+			"RepairMode": "bootstrap"
+			}`
+		})
+
+		It("does not serialize Password in JSON output", func() {
+			data, err := json.Marshal(rootConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).NotTo(ContainSubstring("fake-password"))
+		})
+
+		It("does not serialize BackendTLS CA in JSON output", func() {
+			rootConfig.BackendTLS.CA = "-----BEGIN CERTIFICATE-----\nfake-ca-cert\n-----END CERTIFICATE-----"
+			data, err := json.Marshal(rootConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(data)).NotTo(ContainSubstring("fake-ca-cert"))
 		})
 	})
 

--- a/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/main.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/main.go
@@ -41,7 +41,8 @@ func main() {
 
 	if err != nil {
 		logger.Error("Failed to repair cluster", err, lager.Data{
-			"config": rootConfig,
+			"repair_mode":      rootConfig.RepairMode,
+			"healthcheck_urls": rootConfig.HealthcheckURLs,
 		})
 		printHumanReadableErr(err, rootConfig.RepairMode)
 		os.Exit(1)

--- a/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/main_test.go
+++ b/src/github.com/cloudfoundry-incubator/cf-mysql-bootstrap/main_test.go
@@ -1,6 +1,9 @@
 package main_test
 
 import (
+	"fmt"
+	"os/exec"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -15,5 +18,31 @@ var _ = Describe("Bootstrap Executable", func() {
 		binaryPath, err := gexec.Build("github.com/cloudfoundry-incubator/cf-mysql-bootstrap")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(binaryPath).To(BeAnExistingFile())
+	})
+
+	Describe("credential safety", func() {
+		It("does not log the galera-agent password when bootstrap fails", func() {
+			binaryPath, err := gexec.Build("github.com/cloudfoundry-incubator/cf-mysql-bootstrap")
+			Expect(err).ToNot(HaveOccurred())
+
+			const sensitivePassword = "s3cr3t-galera-agent-password"
+			config := fmt.Sprintf(`{
+				"HealthcheckURLs": ["http://127.0.0.1:19999"],
+				"Username": "galera-agent",
+				"Password": %q,
+				"RepairMode": "bootstrap"
+			}`, sensitivePassword)
+
+			cmd := exec.Command(binaryPath, fmt.Sprintf("-config=%s", config))
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(session, "10s").Should(gexec.Exit())
+			Expect(session.ExitCode()).NotTo(Equal(0))
+
+			combinedOutput := string(session.Out.Contents()) + string(session.Err.Contents())
+			Expect(combinedOutput).NotTo(ContainSubstring(sensitivePassword),
+				"galera-agent password must not appear in log output")
+		})
 	})
 })


### PR DESCRIPTION
## Summary

- Fixes credential leak where the full `rootConfig` (including plaintext `Password`) was passed to `logger.Error` on bootstrap/rejoin-unsafe failure, causing the galera-agent password to appear in BOSH errand output
- Replaces `lager.Data{"config": rootConfig}` with only non-sensitive fields (`repair_mode`, `healthcheck_urls`)
- Adds `json:"-"` to `Config.Password` and `BackendTLS.CA` as defense-in-depth, preventing future log statements from accidentally re-introducing the leak

Jira: https://vmw-jira.broadcom.net/browse/TNZ-97928

## Test plan

- [ ] New integration test in `main_test.go`: builds binary, runs it against an unreachable galera-agent URL to trigger the failure path, asserts the password string is absent from all output
- [ ] Two new unit tests in `config/config_test.go`: marshal a `Config` to JSON and verify neither `Password` nor `BackendTLS.CA` content appears in the output
- [ ] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)