### PR TITLE
Updated bosh blob percona-xtrabackup-8.4.0-5.tar.gz to percona-xtrabackup-8.4.0-6.tar.gz

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -38,10 +38,10 @@ percona-xtrabackup-8.0.35-35.tar.gz:
   size: 447852862
   object_id: cfe465d2-d13b-46a9-64f1-8ebb44bd7e08
   sha: sha256:012aa40e35d7186da1d0c4ccd20d703b2b56a69dc0d750056d969245226a3d67
-percona-xtrabackup-8.4.0-5.tar.gz:
-  size: 432646274
-  object_id: edf66c32-e051-4a55-561a-bd67bb8a13bb
-  sha: sha256:fadcf27efd2a2596f689388659e2ff5c36debcc051a55974ac8bb4a83c015f57
+percona-xtrabackup-8.4.0-6.tar.gz:
+  size: 432884869
+  object_id: 806fe095-89f3-49e8-6ee0-d226ebc6b0a1
+  sha: sha256:e0e886b78d18b34122bd15b2d80f52fc5df2422260edaa3074820902beecd351
 pkgconf-2.5.1.tar.xz:
   size: 328064
   object_id: 74152211-babf-41d2-794a-2f1abcd5f998


### PR DESCRIPTION
# Feature or Bug Description

Cherry-picked automated bump to percona-xtrabackup v8.4.0-6 from support/1.1x branch to main


# Motivation

Bumps to the latest percona-xtrabackup v8.4

https://docs.percona.com/percona-xtrabackup/8.4/release-notes/8.4.0-6.html
