### PR TITLE
TNZ-97927 Prevent Authorization header leaking into switchboard debug logs

### DIFF
--- a/src/github.com/cloudfoundry-incubator/switchboard/api/cluster.go
+++ b/src/github.com/cloudfoundry-incubator/switchboard/api/cluster.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httputil"
 	"strconv"
 
 	"code.cloudfoundry.org/lager/v3"
@@ -61,14 +60,6 @@ func handleUpdate(
 		return
 	}
 
-	dumpBody := true
-	b, err := httputil.DumpRequest(req, dumpBody)
-	if err != nil {
-		http.Error(w, "Failed to dump http body", http.StatusInternalServerError)
-		return
-	}
-
-	logger.Debug("API /cluster req", lager.Data{"dump": string(b)})
 	logger.Debug("API /cluster req form", lager.Data{"form": req.Form})
 
 	enabledStr := req.Form.Get("trafficEnabled")

--- a/src/github.com/cloudfoundry-incubator/switchboard/api/cluster_test.go
+++ b/src/github.com/cloudfoundry-incubator/switchboard/api/cluster_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -214,6 +215,31 @@ var _ = Describe("ClusterEndpoint", func() {
 
 					Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
 				})
+			})
+		})
+
+		Context("when a PATCH request includes an Authorization header", func() {
+			It("does not log the Authorization header credentials", func() {
+				const password = "supersecretpassword"
+				encodedCreds := base64.StdEncoding.EncodeToString(
+					[]byte("admin:" + password),
+				)
+
+				req, err := http.NewRequest(
+					"PATCH",
+					server.URL()+"?trafficEnabled=true",
+					nil,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				req.SetBasicAuth("admin", password)
+
+				client := &http.Client{}
+				_, err = client.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+
+				logContents := testLogger.Buffer().Contents()
+				Expect(logContents).ToNot(ContainSubstring(encodedCreds),
+					"Authorization header base64 value must not appear in logs")
 			})
 		})
 


### PR DESCRIPTION
## Summary

- `handleUpdate()` in `api/cluster.go` called `httputil.DumpRequest(req, true)` and logged the result at Debug level, serialising the `Authorization: Basic <base64>` header verbatim
- This silently bypassed the redaction already applied by the Logger middleware, which only runs _after_ the inner handler returns
- Fix removes the `DumpRequest` call entirely; the Logger middleware already covers equivalent request metadata (headers without Authorization, body, URL, host, remote addr) for every `/v0` request

## Test plan

- [ ] New red/green test in `api/cluster_test.go`: sends a PATCH with `Authorization: Basic` and asserts the base64 credential value does not appear in debug logs
- [ ] All 28 existing `api` package specs continue to pass
- [ ] `net/http/httputil` import removed; `go vet` clean

Closes [TNZ-97927](https://vmw-jira.broadcom.net/browse/TNZ-97927)

🤖 Generated with [Claude Code](https://claude.com/claude-code)