### PR TITLE
fix(packaging): remove unnecessary rename in percona-xtradb-cluster packages

### DIFF
--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -115,7 +115,6 @@ build() {
     make -j "$(nproc)" install/strip
   )
 
-  mv "${BOSH_INSTALL_TARGET}/doc" "${BOSH_INSTALL_TARGET}/doc.galera"
   rm -fr "${BOSH_INSTALL_TARGET}"/share/garb* "${BOSH_INSTALL_TARGET}/cmake/"
 }
 

--- a/packages/percona-xtradb-cluster-8.4/packaging
+++ b/packages/percona-xtradb-cluster-8.4/packaging
@@ -114,7 +114,6 @@ build() {
     make -j "$(nproc)" install/strip
   )
 
-  mv "${BOSH_INSTALL_TARGET}/doc" "${BOSH_INSTALL_TARGET}/doc.galera"
   rm -fr "${BOSH_INSTALL_TARGET}"/share/garb* "${BOSH_INSTALL_TARGET}/cmake/"
 }
 


### PR DESCRIPTION

Old packaging implementation tried to rename doc to "doc.galera"

As of recent Percona patches (v8.4.10, v8.0.46) the galera docs are store in the standard MySQL "docs" directory in the packages directory.

Renaming now leads to compilation failures as the expect "doc" directory left by legacy galera installation scripts no longer exists.

This commit removes this renaming step to fix failing compilation.

[TNZ-124199]