### PR TITLE
Backport Percona package bumps

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -38,10 +38,10 @@ percona-xtrabackup-2.4.29.tar.gz:
   size: 64667518
   object_id: f196e2a0-e2ba-43ef-7d91-4319f8e6b927
   sha: sha256:c59f0d612ec6a0f530ca3645546fb8af690f62d3ecbd70d33f30d3f56d9e842e
-percona-xtrabackup-8.0.35-35.tar.gz:
-  size: 447852862
-  object_id: cfe465d2-d13b-46a9-64f1-8ebb44bd7e08
-  sha: sha256:012aa40e35d7186da1d0c4ccd20d703b2b56a69dc0d750056d969245226a3d67
+percona-xtrabackup-8.0.35-36.tar.gz:
+  size: 447823107
+  object_id: 3a0293d7-787a-4cf4-60c5-83cf1c9a6744
+  sha: sha256:a73a5e3e055075524968b116f9c2ca7c49eedcae88f7c5ef8227ba84ea3364b6
 percona-xtrabackup-8.4.0-6.tar.gz:
   size: 432884869
   object_id: 806fe095-89f3-49e8-6ee0-d226ebc6b0a1

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -6,10 +6,10 @@ Percona-XtraDB-Cluster-8.0.46-38.tar.gz:
   size: 529960552
   object_id: f2fcfd15-4847-4cb9-4cc5-7a28b445e95a
   sha: sha256:759250a166681eb4d2025a1c8c68ce9bc483fbd982ec4b061b1bcf07d3e2fff9
-Percona-XtraDB-Cluster-8.4.8-8.tar.gz:
-  size: 506801118
-  object_id: 5b721094-02b7-4a5e-500e-028ba04fdc8a
-  sha: sha256:dab67ec69fe96f2beeaa9c4d5b9c6bc82bcdd970ae9f732f7dd32d622c829666
+Percona-XtraDB-Cluster-8.4.10-10.tar.gz:
+  size: 507260341
+  object_id: 775580cb-1bcd-4b93-59db-a2e9c61a3ecd
+  sha: sha256:02eecdb76572704967788fb090fc62d8acfdc6a474f85c9cbfb22e9db0942945
 boost_1_59_0.tar.bz2:
   size: 70389425
   object_id: 7344fc77-b911-45c2-5467-c6d5fcab6d29

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,10 +2,10 @@ Percona-XtraDB-Cluster-5.7.44-31.65-5.tar.gz:
   size: 73188463
   object_id: 884878f7-0825-481a-5d2b-9e2b02c72168
   sha: sha256:2a9266599b8827b51e7130b12184805e27e0b15c0178777e9e1f8f90155d4622
-Percona-XtraDB-Cluster-8.0.45-36.tar.gz:
-  size: 529929271
-  object_id: d52a9281-40a7-4cf2-5998-c76a1f41eaf4
-  sha: sha256:cd76970d1c3ce7efb7c563f1b54ca66f3347e67e4d7ec210bf194b1fca81e271
+Percona-XtraDB-Cluster-8.0.46-38.tar.gz:
+  size: 529960552
+  object_id: f2fcfd15-4847-4cb9-4cc5-7a28b445e95a
+  sha: sha256:759250a166681eb4d2025a1c8c68ce9bc483fbd982ec4b061b1bcf07d3e2fff9
 Percona-XtraDB-Cluster-8.4.8-8.tar.gz:
   size: 506801118
   object_id: 5b721094-02b7-4a5e-500e-028ba04fdc8a

--- a/packages/percona-xtradb-cluster-8.0/packaging
+++ b/packages/percona-xtradb-cluster-8.0/packaging
@@ -114,7 +114,6 @@ build() {
     make -j "$(nproc)" install/strip
   )
 
-  mv "${BOSH_INSTALL_TARGET}/doc" "${BOSH_INSTALL_TARGET}/doc.galera"
   rm -fr "${BOSH_INSTALL_TARGET}"/share/garb* "${BOSH_INSTALL_TARGET}/cmake/"
 }
 

--- a/packages/percona-xtradb-cluster-8.4/packaging
+++ b/packages/percona-xtradb-cluster-8.4/packaging
@@ -113,7 +113,6 @@ build() {
     make -j "$(nproc)" install/strip
   )
 
-  mv "${BOSH_INSTALL_TARGET}/doc" "${BOSH_INSTALL_TARGET}/doc.galera"
   rm -fr "${BOSH_INSTALL_TARGET}"/share/garb* "${BOSH_INSTALL_TARGET}/cmake/"
 }
 


### PR DESCRIPTION
Cherry-picks from the main branch to pull into the v1.1 support branch.