### PR TITLE
feat(pxc-mysql): Mitigate mysql bug #116741

### DIFF
--- a/jobs/pxc-mysql/templates/my.cnf.erb
+++ b/jobs/pxc-mysql/templates/my.cnf.erb
@@ -14,6 +14,12 @@
       section_entries
     end
 
+    def override_or_default(section, key, default)
+      section_entries = @entries[section]
+      return default unless section_entries.is_a?(Hash) && section_entries.key?(key)
+      section_entries.delete(key)
+    end
+
     def available_sections
       @entries.keys
     end
@@ -156,6 +162,21 @@ userstat                        = <%= bool_to_on_off(p('engine_config.userstat')
 
 max_heap_table_size             = <%= p('engine_config.max_heap_table_size') %>
 tmp_table_size                  = <%= p('engine_config.tmp_table_size') %>
+# TEMPORARY mitigation for https://bugs.mysql.com/bug.php?id=116741 (incorrect query
+# results when an in-memory temp table spills to an on-disk InnoDB temp table).
+# Fixed upstream in MySQL 8.4.11; remove once Percona XtraDB Cluster ships a v8.4.11-based
+# release (PXC typically lags upstream MySQL by 1-2 months) and revert to the v8.4 default
+# of disabling TempTable mmap (temptable_use_mmap=off), since both variables are deprecated
+# and slated for removal in MySQL 9.7.
+#
+# Deliberately hardcoded rather than exposed as new job properties: this is a short-lived
+# workaround, not a feature, and it can already be overridden per-deployment via the
+# existing engine_config.additional_raw_entries mechanism if needed.
+#
+# Note: on 8.4, temptable_max_mmap has no effect unless temptable_use_mmap is also on -
+# the "modern equivalent" framing in MySQL docs only applies starting in 9.7.
+temptable_use_mmap              = <%= additional_entries.override_or_default('mysqld', 'temptable_use_mmap', 'on') %>
+temptable_max_mmap              = <%= additional_entries.override_or_default('mysqld', 'temptable_max_mmap', '1G') %>
 
 default_storage_engine          = InnoDB
 innodb_autoinc_lock_mode        = 2

--- a/spec/pxc-mysql/mycnf_spec.rb
+++ b/spec/pxc-mysql/mycnf_spec.rb
@@ -47,6 +47,35 @@ describe 'my.cnf template' do
     end
   }
 
+  it 'temporarily enabled deprecated TempTable mmap options to mitigate https://bugs.mysql.com/bug.php?id=116741' do
+      expect(parsed_mycnf).to include("mysqld" => hash_including(
+        "temptable_use_mmap" => "on",
+        "temptable_max_mmap" => "1G"
+      ))
+  end
+
+  context 'when a user overrides temptable settings' do
+    let(:spec) {
+      {
+        "engine_config" => {
+          "additional_raw_entries" => {
+            "mysqld" => {
+              "temptable_use_mmap" => "off",  # prove we can turn temptable mmap back off, if desired
+              "some-other-option" => "some-value", # prove some other override option works too
+            }
+          }
+        }
+      }
+    }
+
+    it 'uses the overrides' do
+      expect(parsed_mycnf).to include("mysqld" => hash_including(
+        "temptable_use_mmap" => "off",
+        "some-other-option" => "some-value"
+      ))
+    end
+  end
+
   it 'sets the authentication policy to what is provided in the job spec' do
       expect(parsed_mycnf).to include("mysqld" => hash_including("authentication_policy" => "caching_sha2_password"))
   end


### PR DESCRIPTION
This MySQL bug can result in incorrect results for queries performing CONST lookup from a temporary table that has been converted to an on-disk table.

The mitigation here is to restore MySQL v8.0 defaults and re-enable the TempTable 1GiB mmap spilover before the internal MySQL conversion to an InnoDB temporary table.

This addresses a common case where light memory pressure can lead to specific query workloads returning incorrect (typically empty) results, but do not fully address the issue.

This will be reverted in the future once Percona XtraDB Cluster v8.4.11 has been released and incorporates a full fix for this defect.
